### PR TITLE
introduce typed instruction decoders

### DIFF
--- a/instruction_decoder.go
+++ b/instruction_decoder.go
@@ -1,0 +1,55 @@
+package solana
+
+import (
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+// TypedInstructionDecoder implementations decode the instruction at the
+// provided index in the message to the provided type.
+type TypedInstructionDecoder[A any] func(*Message, int) (A, error)
+
+// DecodeInstructionType decodes instruction at index in the message using the
+// provided decoders. Returning the requested type. It's expected that this is
+// used in conjunction with typed instructions in the program packages.
+func DecodeInstructionType[A interface {
+	Instruction
+	Obtain(*bin.VariantDefinition) (bin.TypeID, string, interface{})
+}, B any](
+	expectedProgramID PublicKey,
+	def *bin.VariantDefinition,
+	decodeFn func([]*AccountMeta, []byte) (A, error),
+) TypedInstructionDecoder[B] {
+	var (
+		a A
+		b B
+	)
+	return func(msg *Message, index int) (B, error) {
+		if len(msg.Instructions) <= index {
+			return b, fmt.Errorf("transaction doesn't have an instruction at index '%d'", index)
+		}
+		instruction := msg.Instructions[index]
+		accs, err := instruction.ResolveInstructionAccounts(msg)
+		if err != nil {
+			return b, fmt.Errorf("instruction '%d': failed to resolve accounts: %w", index, err)
+		}
+		programID, err := msg.ResolveProgramIDIndex(instruction.ProgramIDIndex)
+		if err != nil {
+			return b, fmt.Errorf("instruction '%d': failed to resolve program ID: %w", index, err)
+		}
+		if !programID.Equals(expectedProgramID) {
+			return b, fmt.Errorf("instruction '%d': programID (%s) doesn't match expected value '%s'", index, programID, expectedProgramID)
+		}
+		decoded, err := decodeFn(accs, instruction.Data)
+		if err != nil {
+			return b, fmt.Errorf("instruction '%d': failed to decode as '%T': %w", index, a, err)
+		}
+		_, _, obtained := decoded.Obtain(def)
+		v, ok := obtained.(B)
+		if !ok {
+			return b, fmt.Errorf("instruction '%d': obtained type '%T' doesn't match expected type '%T'", index, obtained, b)
+		}
+		return v, nil
+	}
+}

--- a/programs/associated-token-account/instruction_decoder.go
+++ b/programs/associated-token-account/instruction_decoder.go
@@ -1,0 +1,17 @@
+package associatedtokenaccount
+
+import (
+	"github.com/gagliardetto/solana-go"
+)
+
+var (
+	DecodeCreate solana.TypedInstructionDecoder[*Create] = decode[*Create]()
+)
+
+func decode[T any]() solana.TypedInstructionDecoder[T] {
+	return solana.DecodeInstructionType[*Instruction, T](
+		ProgramID,
+		InstructionImplDef,
+		DecodeInstruction,
+	)
+}

--- a/programs/compute-budget/instruction_decoder.go
+++ b/programs/compute-budget/instruction_decoder.go
@@ -1,0 +1,20 @@
+package computebudget
+
+import (
+	"github.com/gagliardetto/solana-go"
+)
+
+var (
+	DecodeRequestHeapFrame       solana.TypedInstructionDecoder[*RequestHeapFrame]       = decode[*RequestHeapFrame]()
+	DecodeRequestUnitsDeprecated solana.TypedInstructionDecoder[*RequestUnitsDeprecated] = decode[*RequestUnitsDeprecated]()
+	DecodeSetComputeUnitLimit    solana.TypedInstructionDecoder[*SetComputeUnitLimit]    = decode[*SetComputeUnitLimit]()
+	DecodeSetComputeUnitPrice    solana.TypedInstructionDecoder[*SetComputeUnitPrice]    = decode[*SetComputeUnitPrice]()
+)
+
+func decode[T any]() solana.TypedInstructionDecoder[T] {
+	return solana.DecodeInstructionType[*Instruction, T](
+		ProgramID,
+		InstructionImplDef,
+		DecodeInstruction,
+	)
+}

--- a/programs/system/instruction_decoder.go
+++ b/programs/system/instruction_decoder.go
@@ -1,0 +1,28 @@
+package system
+
+import (
+	"github.com/gagliardetto/solana-go"
+)
+
+var (
+	DecodeAdvanceNonceAccount    solana.TypedInstructionDecoder[*AdvanceNonceAccount]    = decode[*AdvanceNonceAccount]()
+	DecodeAllocate               solana.TypedInstructionDecoder[*Allocate]               = decode[*Allocate]()
+	DecodeAllocateWithSeed       solana.TypedInstructionDecoder[*AllocateWithSeed]       = decode[*AllocateWithSeed]()
+	DecodeAssign                 solana.TypedInstructionDecoder[*Assign]                 = decode[*Assign]()
+	DecodeAssignWithSeed         solana.TypedInstructionDecoder[*AssignWithSeed]         = decode[*AssignWithSeed]()
+	DecodeAuthorizeNonceAccount  solana.TypedInstructionDecoder[*AuthorizeNonceAccount]  = decode[*AuthorizeNonceAccount]()
+	DecodeCreateAccount          solana.TypedInstructionDecoder[*CreateAccount]          = decode[*CreateAccount]()
+	DecodeCreateAccountWithSeed  solana.TypedInstructionDecoder[*CreateAccountWithSeed]  = decode[*CreateAccountWithSeed]()
+	DecodeInitializeNonceAccount solana.TypedInstructionDecoder[*InitializeNonceAccount] = decode[*InitializeNonceAccount]()
+	DecodeTransfer               solana.TypedInstructionDecoder[*Transfer]               = decode[*Transfer]()
+	DecodeTransferWithSeed       solana.TypedInstructionDecoder[*TransferWithSeed]       = decode[*TransferWithSeed]()
+	DecodeWithdrawNonceAccount   solana.TypedInstructionDecoder[*WithdrawNonceAccount]   = decode[*WithdrawNonceAccount]()
+)
+
+func decode[T any]() solana.TypedInstructionDecoder[T] {
+	return solana.DecodeInstructionType[*Instruction, T](
+		ProgramID,
+		InstructionImplDef,
+		DecodeInstruction,
+	)
+}

--- a/programs/token/instruction_decoder.go
+++ b/programs/token/instruction_decoder.go
@@ -1,0 +1,37 @@
+package token
+
+import (
+	"github.com/gagliardetto/solana-go"
+)
+
+var (
+	DecodeApprove             solana.TypedInstructionDecoder[*Approve]             = decode[*Approve]()
+	DecodeApproveChecked      solana.TypedInstructionDecoder[*ApproveChecked]      = decode[*ApproveChecked]()
+	DecodeBurn                solana.TypedInstructionDecoder[*Burn]                = decode[*Burn]()
+	DecodeBurnChecked         solana.TypedInstructionDecoder[*BurnChecked]         = decode[*BurnChecked]()
+	DecodeCloseAccount        solana.TypedInstructionDecoder[*CloseAccount]        = decode[*CloseAccount]()
+	DecodeFreezeAccount       solana.TypedInstructionDecoder[*FreezeAccount]       = decode[*FreezeAccount]()
+	DecodeInitializeAccount   solana.TypedInstructionDecoder[*InitializeAccount]   = decode[*InitializeAccount]()
+	DecodeInitializeAccount2  solana.TypedInstructionDecoder[*InitializeAccount2]  = decode[*InitializeAccount2]()
+	DecodeInitializeAccount3  solana.TypedInstructionDecoder[*InitializeAccount3]  = decode[*InitializeAccount3]()
+	DecodeInitializeMint      solana.TypedInstructionDecoder[*InitializeMint]      = decode[*InitializeMint]()
+	DecodeInitializeMint2     solana.TypedInstructionDecoder[*InitializeMint2]     = decode[*InitializeMint2]()
+	DecodeInitializeMultisig  solana.TypedInstructionDecoder[*InitializeMultisig]  = decode[*InitializeMultisig]()
+	DecodeInitializeMultisig2 solana.TypedInstructionDecoder[*InitializeMultisig2] = decode[*InitializeMultisig2]()
+	DecodeMintTo              solana.TypedInstructionDecoder[*MintTo]              = decode[*MintTo]()
+	DecodeMintToChecked       solana.TypedInstructionDecoder[*MintToChecked]       = decode[*MintToChecked]()
+	DecodeRevoke              solana.TypedInstructionDecoder[*Revoke]              = decode[*Revoke]()
+	DecodeSetAuthority        solana.TypedInstructionDecoder[*SetAuthority]        = decode[*SetAuthority]()
+	DecodeSyncNative          solana.TypedInstructionDecoder[*SyncNative]          = decode[*SyncNative]()
+	DecodeThawAccount         solana.TypedInstructionDecoder[*ThawAccount]         = decode[*ThawAccount]()
+	DecodeTransfer            solana.TypedInstructionDecoder[*Transfer]            = decode[*Transfer]()
+	DecodeTransferChecked     solana.TypedInstructionDecoder[*TransferChecked]     = decode[*TransferChecked]()
+)
+
+func decode[T any]() solana.TypedInstructionDecoder[T] {
+	return solana.DecodeInstructionType[*Instruction, T](
+		ProgramID,
+		InstructionImplDef,
+		DecodeInstruction,
+	)
+}

--- a/programs/vote/instruction_decoder.go
+++ b/programs/vote/instruction_decoder.go
@@ -1,0 +1,19 @@
+package vote
+
+import (
+	"github.com/gagliardetto/solana-go"
+)
+
+var (
+	DecodeAuthorize         solana.TypedInstructionDecoder[*Authorize]         = decode[*Authorize]()
+	DecodeInitializeAccount solana.TypedInstructionDecoder[*InitializeAccount] = decode[*InitializeAccount]()
+	DecodeWithdraw          solana.TypedInstructionDecoder[*Withdraw]          = decode[*Withdraw]()
+)
+
+func decode[T any]() solana.TypedInstructionDecoder[T] {
+	return solana.DecodeInstructionType[*Instruction, T](
+		ProgramID,
+		InstructionImplDef,
+		DecodeInstruction,
+	)
+}


### PR DESCRIPTION
This PR introduces a bunch of typed instruction decoders, which are slightly more user friendly adapters around the existing `DecodeInstruction` functions for each program type. 

These can be used if you know the type of instruction you're expecting for a given instruction - they're nice in that they take care of unwrapping the `interface{}` decoded types to concrete types.