### PR TITLE
Fix `associatedtokenaccount` program to work with `Token2022`

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -642,8 +642,14 @@ func FindProgramAddress(seed [][]byte, programID PublicKey) (PublicKey, uint8, e
 }
 
 // MustFindassociatedTokenAddress panicing if resolving fails.
-func MustFindAssociatedTokenAddress(wallet, mint PublicKey) PublicKey {
-	token, _, err := FindAssociatedTokenAddress(wallet, mint)
+func MustFindAssociatedTokenAddress(
+	wallet PublicKey,
+	mint PublicKey,
+	programID PublicKey,
+) PublicKey {
+	token, _, err := FindAssociatedTokenAddress(
+		wallet, mint, programID,
+	)
 	if err != nil {
 		panic(err)
 	}
@@ -653,11 +659,12 @@ func MustFindAssociatedTokenAddress(wallet, mint PublicKey) PublicKey {
 func FindAssociatedTokenAddress(
 	wallet PublicKey,
 	mint PublicKey,
+	programID PublicKey,
 ) (PublicKey, uint8, error) {
 	return findAssociatedTokenAddressAndBumpSeed(
 		wallet,
 		mint,
-		SPLAssociatedTokenAccountProgramID,
+		programID,
 	)
 }
 
@@ -668,10 +675,10 @@ func findAssociatedTokenAddressAndBumpSeed(
 ) (PublicKey, uint8, error) {
 	return FindProgramAddress([][]byte{
 		walletAddress[:],
-		TokenProgramID[:],
+		programID[:],
 		splTokenMintAddress[:],
 	},
-		programID,
+		SPLAssociatedTokenAccountProgramID,
 	)
 }
 

--- a/program_ids.go
+++ b/program_ids.go
@@ -46,6 +46,9 @@ var (
 	// A Token program on the Solana blockchain.
 	// This program defines a common implementation for Fungible and Non Fungible tokens.
 	TokenProgramID = MustPublicKeyFromBase58("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+	// Token2022ProgramID for the _new_ spl-token 2022 program. This is an
+	// extension of the default token token program.
+	Token2022ProgramID = MustPublicKeyFromBase58("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb")
 
 	// A Uniswap-like exchange for the Token program on the Solana blockchain,
 	// implementing multiple automated market maker (AMM) curves.

--- a/programs/associated-token-account/Create.go
+++ b/programs/associated-token-account/Create.go
@@ -25,9 +25,10 @@ import (
 )
 
 type Create struct {
-	Payer  solana.PublicKey `bin:"-" borsh_skip:"true"`
-	Wallet solana.PublicKey `bin:"-" borsh_skip:"true"`
-	Mint   solana.PublicKey `bin:"-" borsh_skip:"true"`
+	Payer          solana.PublicKey `bin:"-" borsh_skip:"true"`
+	Wallet         solana.PublicKey `bin:"-" borsh_skip:"true"`
+	Mint           solana.PublicKey `bin:"-" borsh_skip:"true"`
+	TokenProgramID solana.PublicKey `bin:"-" borsh_skip:"true"`
 
 	// [0] = [WRITE, SIGNER] Payer
 	// ··········· Funding account
@@ -73,12 +74,18 @@ func (inst *Create) SetMint(mint solana.PublicKey) *Create {
 	return inst
 }
 
+func (inst *Create) SetTokenProgramID(tokenProgramID solana.PublicKey) *Create {
+	inst.TokenProgramID = tokenProgramID
+	return inst
+}
+
 func (inst Create) Build() *Instruction {
 
 	// Find the associatedTokenAddress;
 	associatedTokenAddress, _, _ := solana.FindAssociatedTokenAddress(
 		inst.Wallet,
 		inst.Mint,
+		inst.TokenProgramID,
 	)
 
 	keys := []*solana.AccountMeta{
@@ -108,7 +115,7 @@ func (inst Create) Build() *Instruction {
 			IsWritable: false,
 		},
 		{
-			PublicKey:  solana.TokenProgramID,
+			PublicKey:  inst.TokenProgramID,
 			IsSigner:   false,
 			IsWritable: false,
 		},
@@ -150,6 +157,7 @@ func (inst *Create) Validate() error {
 	_, _, err := solana.FindAssociatedTokenAddress(
 		inst.Wallet,
 		inst.Mint,
+		inst.TokenProgramID,
 	)
 	if err != nil {
 		return fmt.Errorf("error while FindAssociatedTokenAddress: %w", err)
@@ -194,9 +202,11 @@ func NewCreateInstruction(
 	payer solana.PublicKey,
 	walletAddress solana.PublicKey,
 	splTokenMintAddress solana.PublicKey,
+	tokenProgramID solana.PublicKey,
 ) *Create {
 	return NewCreateInstructionBuilder().
 		SetPayer(payer).
 		SetWallet(walletAddress).
-		SetMint(splTokenMintAddress)
+		SetMint(splTokenMintAddress).
+		SetTokenProgramID(tokenProgramID)
 }


### PR DESCRIPTION
This required: 
1. Updating the `FindAssociatedTokenAddress` function to accept program ID as a variable
2. Updating the `associatedtokenaccount.Create` instruction to accept program ID as a variable