### PR TITLE
add token2022 programs

### DIFF
--- a/programs/token2022/Approve.go
+++ b/programs/token2022/Approve.go
@@ -1,0 +1,230 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Approves a delegate.  A delegate is given the authority over tokens on
+// behalf of the source account's owner.
+type Approve struct {
+	// The amount of tokens the delegate is approved for.
+	Amount *uint64
+
+	// [0] = [WRITE] source
+	// ··········· The source account.
+	//
+	// [1] = [] delegate
+	// ··········· The delegate.
+	//
+	// [2] = [] owner
+	// ··········· The source account owner.
+	//
+	// [3...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *Approve) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(3)
+	return nil
+}
+
+func (slice Approve) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewApproveInstructionBuilder creates a new `Approve` instruction builder.
+func NewApproveInstructionBuilder() *Approve {
+	nd := &Approve{
+		Accounts: make(ag_solanago.AccountMetaSlice, 3),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetAmount sets the "amount" parameter.
+// The amount of tokens the delegate is approved for.
+func (inst *Approve) SetAmount(amount uint64) *Approve {
+	inst.Amount = &amount
+	return inst
+}
+
+// SetSourceAccount sets the "source" account.
+// The source account.
+func (inst *Approve) SetSourceAccount(source ag_solanago.PublicKey) *Approve {
+	inst.Accounts[0] = ag_solanago.Meta(source).WRITE()
+	return inst
+}
+
+// GetSourceAccount gets the "source" account.
+// The source account.
+func (inst *Approve) GetSourceAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetDelegateAccount sets the "delegate" account.
+// The delegate.
+func (inst *Approve) SetDelegateAccount(delegate ag_solanago.PublicKey) *Approve {
+	inst.Accounts[1] = ag_solanago.Meta(delegate)
+	return inst
+}
+
+// GetDelegateAccount gets the "delegate" account.
+// The delegate.
+func (inst *Approve) GetDelegateAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetOwnerAccount sets the "owner" account.
+// The source account owner.
+func (inst *Approve) SetOwnerAccount(owner ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *Approve {
+	inst.Accounts[2] = ag_solanago.Meta(owner)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[2].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetOwnerAccount gets the "owner" account.
+// The source account owner.
+func (inst *Approve) GetOwnerAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+func (inst Approve) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_Approve),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst Approve) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *Approve) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Amount == nil {
+			return errors.New("Amount parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Source is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.Delegate is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return errors.New("accounts.Owner is not set")
+		}
+		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *Approve) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("Approve")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("Amount", *inst.Amount))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("  source", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("delegate", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("   owner", inst.Accounts[2]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj Approve) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Amount` param:
+	err = encoder.Encode(obj.Amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *Approve) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Amount`:
+	err = decoder.Decode(&obj.Amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewApproveInstruction declares a new Approve instruction with the provided parameters and accounts.
+func NewApproveInstruction(
+	// Parameters:
+	amount uint64,
+	// Accounts:
+	source ag_solanago.PublicKey,
+	delegate ag_solanago.PublicKey,
+	owner ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *Approve {
+	return NewApproveInstructionBuilder().
+		SetAmount(amount).
+		SetSourceAccount(source).
+		SetDelegateAccount(delegate).
+		SetOwnerAccount(owner, multisigSigners...)
+}

--- a/programs/token2022/ApproveChecked.go
+++ b/programs/token2022/ApproveChecked.go
@@ -1,0 +1,282 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Approves a delegate.  A delegate is given the authority over tokens on
+// behalf of the source account's owner.
+//
+// This instruction differs from Approve in that the token mint and
+// decimals value is checked by the caller.  This may be useful when
+// creating transactions offline or within a hardware wallet.
+type ApproveChecked struct {
+	// The amount of tokens the delegate is approved for.
+	Amount *uint64
+
+	// Expected number of base 10 digits to the right of the decimal place.
+	Decimals *uint8
+
+	// [0] = [WRITE] source
+	// ··········· The source account.
+	//
+	// [1] = [] mint
+	// ··········· The token mint.
+	//
+	// [2] = [] delegate
+	// ··········· The delegate.
+	//
+	// [3] = [] owner
+	// ··········· The source account owner.
+	//
+	// [4...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *ApproveChecked) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(4)
+	return nil
+}
+
+func (slice ApproveChecked) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewApproveCheckedInstructionBuilder creates a new `ApproveChecked` instruction builder.
+func NewApproveCheckedInstructionBuilder() *ApproveChecked {
+	nd := &ApproveChecked{
+		Accounts: make(ag_solanago.AccountMetaSlice, 4),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetAmount sets the "amount" parameter.
+// The amount of tokens the delegate is approved for.
+func (inst *ApproveChecked) SetAmount(amount uint64) *ApproveChecked {
+	inst.Amount = &amount
+	return inst
+}
+
+// SetDecimals sets the "decimals" parameter.
+// Expected number of base 10 digits to the right of the decimal place.
+func (inst *ApproveChecked) SetDecimals(decimals uint8) *ApproveChecked {
+	inst.Decimals = &decimals
+	return inst
+}
+
+// SetSourceAccount sets the "source" account.
+// The source account.
+func (inst *ApproveChecked) SetSourceAccount(source ag_solanago.PublicKey) *ApproveChecked {
+	inst.Accounts[0] = ag_solanago.Meta(source).WRITE()
+	return inst
+}
+
+// GetSourceAccount gets the "source" account.
+// The source account.
+func (inst *ApproveChecked) GetSourceAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetMintAccount sets the "mint" account.
+// The token mint.
+func (inst *ApproveChecked) SetMintAccount(mint ag_solanago.PublicKey) *ApproveChecked {
+	inst.Accounts[1] = ag_solanago.Meta(mint)
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The token mint.
+func (inst *ApproveChecked) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetDelegateAccount sets the "delegate" account.
+// The delegate.
+func (inst *ApproveChecked) SetDelegateAccount(delegate ag_solanago.PublicKey) *ApproveChecked {
+	inst.Accounts[2] = ag_solanago.Meta(delegate)
+	return inst
+}
+
+// GetDelegateAccount gets the "delegate" account.
+// The delegate.
+func (inst *ApproveChecked) GetDelegateAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+// SetOwnerAccount sets the "owner" account.
+// The source account owner.
+func (inst *ApproveChecked) SetOwnerAccount(owner ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *ApproveChecked {
+	inst.Accounts[3] = ag_solanago.Meta(owner)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[3].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetOwnerAccount gets the "owner" account.
+// The source account owner.
+func (inst *ApproveChecked) GetOwnerAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[3]
+}
+
+func (inst ApproveChecked) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_ApproveChecked),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst ApproveChecked) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *ApproveChecked) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Amount == nil {
+			return errors.New("Amount parameter is not set")
+		}
+		if inst.Decimals == nil {
+			return errors.New("Decimals parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Source is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return errors.New("accounts.Delegate is not set")
+		}
+		if inst.Accounts[3] == nil {
+			return errors.New("accounts.Owner is not set")
+		}
+		if !inst.Accounts[3].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *ApproveChecked) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("ApproveChecked")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("  Amount", *inst.Amount))
+						paramsBranch.Child(ag_format.Param("Decimals", *inst.Decimals))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("  source", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("    mint", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("delegate", inst.Accounts[2]))
+						accountsBranch.Child(ag_format.Meta("   owner", inst.Accounts[3]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj ApproveChecked) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Amount` param:
+	err = encoder.Encode(obj.Amount)
+	if err != nil {
+		return err
+	}
+	// Serialize `Decimals` param:
+	err = encoder.Encode(obj.Decimals)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *ApproveChecked) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Amount`:
+	err = decoder.Decode(&obj.Amount)
+	if err != nil {
+		return err
+	}
+	// Deserialize `Decimals`:
+	err = decoder.Decode(&obj.Decimals)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewApproveCheckedInstruction declares a new ApproveChecked instruction with the provided parameters and accounts.
+func NewApproveCheckedInstruction(
+	// Parameters:
+	amount uint64,
+	decimals uint8,
+	// Accounts:
+	source ag_solanago.PublicKey,
+	mint ag_solanago.PublicKey,
+	delegate ag_solanago.PublicKey,
+	owner ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *ApproveChecked {
+	return NewApproveCheckedInstructionBuilder().
+		SetAmount(amount).
+		SetDecimals(decimals).
+		SetSourceAccount(source).
+		SetMintAccount(mint).
+		SetDelegateAccount(delegate).
+		SetOwnerAccount(owner, multisigSigners...)
+}

--- a/programs/token2022/ApproveChecked_test.go
+++ b/programs/token2022/ApproveChecked_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_ApproveChecked(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("ApproveChecked"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(ApproveChecked)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(ApproveChecked)
+				err = decodeT(got, buf.Bytes())
+				params.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/Approve_test.go
+++ b/programs/token2022/Approve_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_Approve(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("Approve"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(Approve)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(Approve)
+				err = decodeT(got, buf.Bytes())
+				got.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/Burn.go
+++ b/programs/token2022/Burn.go
@@ -1,0 +1,230 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Burns tokens by removing them from an account.  `Burn` does not support
+// accounts associated with the native mint, use `CloseAccount` instead.
+type Burn struct {
+	// The amount of tokens to burn.
+	Amount *uint64
+
+	// [0] = [WRITE] source
+	// ··········· The account to burn from.
+	//
+	// [1] = [WRITE] mint
+	// ··········· The token mint.
+	//
+	// [2] = [] owner
+	// ··········· The account's owner/delegate.
+	//
+	// [3...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *Burn) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(3)
+	return nil
+}
+
+func (slice Burn) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewBurnInstructionBuilder creates a new `Burn` instruction builder.
+func NewBurnInstructionBuilder() *Burn {
+	nd := &Burn{
+		Accounts: make(ag_solanago.AccountMetaSlice, 3),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetAmount sets the "amount" parameter.
+// The amount of tokens to burn.
+func (inst *Burn) SetAmount(amount uint64) *Burn {
+	inst.Amount = &amount
+	return inst
+}
+
+// SetSourceAccount sets the "source" account.
+// The account to burn from.
+func (inst *Burn) SetSourceAccount(source ag_solanago.PublicKey) *Burn {
+	inst.Accounts[0] = ag_solanago.Meta(source).WRITE()
+	return inst
+}
+
+// GetSourceAccount gets the "source" account.
+// The account to burn from.
+func (inst *Burn) GetSourceAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetMintAccount sets the "mint" account.
+// The token mint.
+func (inst *Burn) SetMintAccount(mint ag_solanago.PublicKey) *Burn {
+	inst.Accounts[1] = ag_solanago.Meta(mint).WRITE()
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The token mint.
+func (inst *Burn) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetOwnerAccount sets the "owner" account.
+// The account's owner/delegate.
+func (inst *Burn) SetOwnerAccount(owner ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *Burn {
+	inst.Accounts[2] = ag_solanago.Meta(owner)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[2].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetOwnerAccount gets the "owner" account.
+// The account's owner/delegate.
+func (inst *Burn) GetOwnerAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+func (inst Burn) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_Burn),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst Burn) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *Burn) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Amount == nil {
+			return errors.New("Amount parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Source is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return errors.New("accounts.Owner is not set")
+		}
+		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *Burn) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("Burn")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("Amount", *inst.Amount))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("source", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("  mint", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta(" owner", inst.Accounts[2]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj Burn) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Amount` param:
+	err = encoder.Encode(obj.Amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *Burn) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Amount`:
+	err = decoder.Decode(&obj.Amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewBurnInstruction declares a new Burn instruction with the provided parameters and accounts.
+func NewBurnInstruction(
+	// Parameters:
+	amount uint64,
+	// Accounts:
+	source ag_solanago.PublicKey,
+	mint ag_solanago.PublicKey,
+	owner ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *Burn {
+	return NewBurnInstructionBuilder().
+		SetAmount(amount).
+		SetSourceAccount(source).
+		SetMintAccount(mint).
+		SetOwnerAccount(owner, multisigSigners...)
+}

--- a/programs/token2022/BurnChecked.go
+++ b/programs/token2022/BurnChecked.go
@@ -1,0 +1,261 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Burns tokens by removing them from an account.  `BurnChecked` does not
+// support accounts associated with the native mint, use `CloseAccount`
+// instead.
+//
+// This instruction differs from Burn in that the decimals value is checked
+// by the caller. This may be useful when creating transactions offline or
+// within a hardware wallet.
+type BurnChecked struct {
+	// The amount of tokens to burn.
+	Amount *uint64
+
+	// Expected number of base 10 digits to the right of the decimal place.
+	Decimals *uint8
+
+	// [0] = [WRITE] source
+	// ··········· The account to burn from.
+	//
+	// [1] = [WRITE] mint
+	// ··········· The token mint.
+	//
+	// [2] = [] owner
+	// ··········· The account's owner/delegate.
+	//
+	// [3...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *BurnChecked) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(3)
+	return nil
+}
+
+func (slice BurnChecked) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewBurnCheckedInstructionBuilder creates a new `BurnChecked` instruction builder.
+func NewBurnCheckedInstructionBuilder() *BurnChecked {
+	nd := &BurnChecked{
+		Accounts: make(ag_solanago.AccountMetaSlice, 3),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetAmount sets the "amount" parameter.
+// The amount of tokens to burn.
+func (inst *BurnChecked) SetAmount(amount uint64) *BurnChecked {
+	inst.Amount = &amount
+	return inst
+}
+
+// SetDecimals sets the "decimals" parameter.
+// Expected number of base 10 digits to the right of the decimal place.
+func (inst *BurnChecked) SetDecimals(decimals uint8) *BurnChecked {
+	inst.Decimals = &decimals
+	return inst
+}
+
+// SetSourceAccount sets the "source" account.
+// The account to burn from.
+func (inst *BurnChecked) SetSourceAccount(source ag_solanago.PublicKey) *BurnChecked {
+	inst.Accounts[0] = ag_solanago.Meta(source).WRITE()
+	return inst
+}
+
+// GetSourceAccount gets the "source" account.
+// The account to burn from.
+func (inst *BurnChecked) GetSourceAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetMintAccount sets the "mint" account.
+// The token mint.
+func (inst *BurnChecked) SetMintAccount(mint ag_solanago.PublicKey) *BurnChecked {
+	inst.Accounts[1] = ag_solanago.Meta(mint).WRITE()
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The token mint.
+func (inst *BurnChecked) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetOwnerAccount sets the "owner" account.
+// The account's owner/delegate.
+func (inst *BurnChecked) SetOwnerAccount(owner ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *BurnChecked {
+	inst.Accounts[2] = ag_solanago.Meta(owner)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[2].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetOwnerAccount gets the "owner" account.
+// The account's owner/delegate.
+func (inst *BurnChecked) GetOwnerAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+func (inst BurnChecked) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_BurnChecked),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst BurnChecked) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *BurnChecked) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Amount == nil {
+			return errors.New("Amount parameter is not set")
+		}
+		if inst.Decimals == nil {
+			return errors.New("Decimals parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Source is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return errors.New("accounts.Owner is not set")
+		}
+		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *BurnChecked) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("BurnChecked")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("  Amount", *inst.Amount))
+						paramsBranch.Child(ag_format.Param("Decimals", *inst.Decimals))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("source", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("  mint", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta(" owner", inst.Accounts[2]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj BurnChecked) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Amount` param:
+	err = encoder.Encode(obj.Amount)
+	if err != nil {
+		return err
+	}
+	// Serialize `Decimals` param:
+	err = encoder.Encode(obj.Decimals)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *BurnChecked) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Amount`:
+	err = decoder.Decode(&obj.Amount)
+	if err != nil {
+		return err
+	}
+	// Deserialize `Decimals`:
+	err = decoder.Decode(&obj.Decimals)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewBurnCheckedInstruction declares a new BurnChecked instruction with the provided parameters and accounts.
+func NewBurnCheckedInstruction(
+	// Parameters:
+	amount uint64,
+	decimals uint8,
+	// Accounts:
+	source ag_solanago.PublicKey,
+	mint ag_solanago.PublicKey,
+	owner ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *BurnChecked {
+	return NewBurnCheckedInstructionBuilder().
+		SetAmount(amount).
+		SetDecimals(decimals).
+		SetSourceAccount(source).
+		SetMintAccount(mint).
+		SetOwnerAccount(owner, multisigSigners...)
+}

--- a/programs/token2022/BurnChecked_test.go
+++ b/programs/token2022/BurnChecked_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_BurnChecked(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("BurnChecked"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(BurnChecked)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(BurnChecked)
+				err = decodeT(got, buf.Bytes())
+				params.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/Burn_test.go
+++ b/programs/token2022/Burn_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_Burn(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("Burn"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(Burn)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(Burn)
+				err = decodeT(got, buf.Bytes())
+				params.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/CloseAccount.go
+++ b/programs/token2022/CloseAccount.go
@@ -1,0 +1,199 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Close an account by transferring all its SOL to the destination account.
+// Non-native accounts may only be closed if its token amount is zero.
+type CloseAccount struct {
+
+	// [0] = [WRITE] account
+	// ··········· The account to close.
+	//
+	// [1] = [WRITE] destination
+	// ··········· The destination account.
+	//
+	// [2] = [] owner
+	// ··········· The account's owner.
+	//
+	// [3...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *CloseAccount) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(3)
+	return nil
+}
+
+func (slice CloseAccount) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewCloseAccountInstructionBuilder creates a new `CloseAccount` instruction builder.
+func NewCloseAccountInstructionBuilder() *CloseAccount {
+	nd := &CloseAccount{
+		Accounts: make(ag_solanago.AccountMetaSlice, 3),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetAccount sets the "account" account.
+// The account to close.
+func (inst *CloseAccount) SetAccount(account ag_solanago.PublicKey) *CloseAccount {
+	inst.Accounts[0] = ag_solanago.Meta(account).WRITE()
+	return inst
+}
+
+// GetAccount gets the "account" account.
+// The account to close.
+func (inst *CloseAccount) GetAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetDestinationAccount sets the "destination" account.
+// The destination account.
+func (inst *CloseAccount) SetDestinationAccount(destination ag_solanago.PublicKey) *CloseAccount {
+	inst.Accounts[1] = ag_solanago.Meta(destination).WRITE()
+	return inst
+}
+
+// GetDestinationAccount gets the "destination" account.
+// The destination account.
+func (inst *CloseAccount) GetDestinationAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetOwnerAccount sets the "owner" account.
+// The account's owner.
+func (inst *CloseAccount) SetOwnerAccount(owner ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *CloseAccount {
+	inst.Accounts[2] = ag_solanago.Meta(owner)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[2].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetOwnerAccount gets the "owner" account.
+// The account's owner.
+func (inst *CloseAccount) GetOwnerAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+func (inst CloseAccount) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_CloseAccount),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst CloseAccount) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *CloseAccount) Validate() error {
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Account is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.Destination is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return errors.New("accounts.Owner is not set")
+		}
+		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *CloseAccount) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("CloseAccount")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("    account", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("destination", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("      owner", inst.Accounts[2]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj CloseAccount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	return nil
+}
+func (obj *CloseAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+// NewCloseAccountInstruction declares a new CloseAccount instruction with the provided parameters and accounts.
+func NewCloseAccountInstruction(
+	// Accounts:
+	account ag_solanago.PublicKey,
+	destination ag_solanago.PublicKey,
+	owner ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *CloseAccount {
+	return NewCloseAccountInstructionBuilder().
+		SetAccount(account).
+		SetDestinationAccount(destination).
+		SetOwnerAccount(owner, multisigSigners...)
+}

--- a/programs/token2022/CloseAccount_test.go
+++ b/programs/token2022/CloseAccount_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_CloseAccount(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("CloseAccount"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(CloseAccount)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(CloseAccount)
+				err = decodeT(got, buf.Bytes())
+				params.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/FreezeAccount.go
+++ b/programs/token2022/FreezeAccount.go
@@ -1,0 +1,198 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Freeze an Initialized account using the Mint's freeze_authority (if set).
+type FreezeAccount struct {
+
+	// [0] = [WRITE] account
+	// ··········· The account to freeze.
+	//
+	// [1] = [] mint
+	// ··········· The token mint.
+	//
+	// [2] = [] authority
+	// ··········· The mint freeze authority.
+	//
+	// [3...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *FreezeAccount) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(3)
+	return nil
+}
+
+func (slice FreezeAccount) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewFreezeAccountInstructionBuilder creates a new `FreezeAccount` instruction builder.
+func NewFreezeAccountInstructionBuilder() *FreezeAccount {
+	nd := &FreezeAccount{
+		Accounts: make(ag_solanago.AccountMetaSlice, 3),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetAccount sets the "account" account.
+// The account to freeze.
+func (inst *FreezeAccount) SetAccount(account ag_solanago.PublicKey) *FreezeAccount {
+	inst.Accounts[0] = ag_solanago.Meta(account).WRITE()
+	return inst
+}
+
+// GetAccount gets the "account" account.
+// The account to freeze.
+func (inst *FreezeAccount) GetAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetMintAccount sets the "mint" account.
+// The token mint.
+func (inst *FreezeAccount) SetMintAccount(mint ag_solanago.PublicKey) *FreezeAccount {
+	inst.Accounts[1] = ag_solanago.Meta(mint)
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The token mint.
+func (inst *FreezeAccount) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetAuthorityAccount sets the "authority" account.
+// The mint freeze authority.
+func (inst *FreezeAccount) SetAuthorityAccount(authority ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *FreezeAccount {
+	inst.Accounts[2] = ag_solanago.Meta(authority)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[2].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetAuthorityAccount gets the "authority" account.
+// The mint freeze authority.
+func (inst *FreezeAccount) GetAuthorityAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+func (inst FreezeAccount) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_FreezeAccount),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst FreezeAccount) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *FreezeAccount) Validate() error {
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Account is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return errors.New("accounts.Authority is not set")
+		}
+		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *FreezeAccount) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("FreezeAccount")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("  account", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("     mint", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("authority", inst.Accounts[2]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj FreezeAccount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	return nil
+}
+func (obj *FreezeAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+// NewFreezeAccountInstruction declares a new FreezeAccount instruction with the provided parameters and accounts.
+func NewFreezeAccountInstruction(
+	// Accounts:
+	account ag_solanago.PublicKey,
+	mint ag_solanago.PublicKey,
+	authority ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *FreezeAccount {
+	return NewFreezeAccountInstructionBuilder().
+		SetAccount(account).
+		SetMintAccount(mint).
+		SetAuthorityAccount(authority, multisigSigners...)
+}

--- a/programs/token2022/FreezeAccount_test.go
+++ b/programs/token2022/FreezeAccount_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_FreezeAccount(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("FreezeAccount"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(FreezeAccount)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(FreezeAccount)
+				err = decodeT(got, buf.Bytes())
+				params.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/InitializeAccount.go
+++ b/programs/token2022/InitializeAccount.go
@@ -1,0 +1,191 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Initializes a new account to hold tokens.  If this account is associated
+// with the native mint then the token balance of the initialized account
+// will be equal to the amount of SOL in the account. If this account is
+// associated with another mint, that mint must be initialized before this
+// command can succeed.
+//
+// The `InitializeAccount` instruction requires no signers and MUST be
+// included within the same Transaction as the system program's
+// `CreateAccount` instruction that creates the account being initialized.
+// Otherwise another party can acquire ownership of the uninitialized
+// account.
+type InitializeAccount struct {
+
+	// [0] = [WRITE] account
+	// ··········· The account to initialize.
+	//
+	// [1] = [] mint
+	// ··········· The mint this account will be associated with.
+	//
+	// [2] = [] owner
+	// ··········· The new account's owner/multisignature.
+	//
+	// [3] = [] $(SysVarRentPubkey)
+	// ··········· Rent sysvar.
+	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+// NewInitializeAccountInstructionBuilder creates a new `InitializeAccount` instruction builder.
+func NewInitializeAccountInstructionBuilder() *InitializeAccount {
+	nd := &InitializeAccount{
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 4),
+	}
+	nd.AccountMetaSlice[3] = ag_solanago.Meta(ag_solanago.SysVarRentPubkey)
+	return nd
+}
+
+// SetAccount sets the "account" account.
+// The account to initialize.
+func (inst *InitializeAccount) SetAccount(account ag_solanago.PublicKey) *InitializeAccount {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(account).WRITE()
+	return inst
+}
+
+// GetAccount gets the "account" account.
+// The account to initialize.
+func (inst *InitializeAccount) GetAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+
+// SetMintAccount sets the "mint" account.
+// The mint this account will be associated with.
+func (inst *InitializeAccount) SetMintAccount(mint ag_solanago.PublicKey) *InitializeAccount {
+	inst.AccountMetaSlice[1] = ag_solanago.Meta(mint)
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The mint this account will be associated with.
+func (inst *InitializeAccount) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[1]
+}
+
+// SetOwnerAccount sets the "owner" account.
+// The new account's owner/multisignature.
+func (inst *InitializeAccount) SetOwnerAccount(owner ag_solanago.PublicKey) *InitializeAccount {
+	inst.AccountMetaSlice[2] = ag_solanago.Meta(owner)
+	return inst
+}
+
+// GetOwnerAccount gets the "owner" account.
+// The new account's owner/multisignature.
+func (inst *InitializeAccount) GetOwnerAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[2]
+}
+
+// SetSysVarRentPubkeyAccount sets the "$(SysVarRentPubkey)" account.
+// Rent sysvar.
+func (inst *InitializeAccount) SetSysVarRentPubkeyAccount(SysVarRentPubkey ag_solanago.PublicKey) *InitializeAccount {
+	inst.AccountMetaSlice[3] = ag_solanago.Meta(SysVarRentPubkey)
+	return inst
+}
+
+// GetSysVarRentPubkeyAccount gets the "$(SysVarRentPubkey)" account.
+// Rent sysvar.
+func (inst *InitializeAccount) GetSysVarRentPubkeyAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[3]
+}
+
+func (inst InitializeAccount) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeAccount),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst InitializeAccount) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *InitializeAccount) Validate() error {
+	// Check whether all (required) accounts are set:
+	{
+		if inst.AccountMetaSlice[0] == nil {
+			return errors.New("accounts.Account is not set")
+		}
+		if inst.AccountMetaSlice[1] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+		if inst.AccountMetaSlice[2] == nil {
+			return errors.New("accounts.Owner is not set")
+		}
+		if inst.AccountMetaSlice[3] == nil {
+			return errors.New("accounts.SysVarRentPubkey is not set")
+		}
+	}
+	return nil
+}
+
+func (inst *InitializeAccount) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("InitializeAccount")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("   account", inst.AccountMetaSlice[0]))
+						accountsBranch.Child(ag_format.Meta("      mint", inst.AccountMetaSlice[1]))
+						accountsBranch.Child(ag_format.Meta("     owner", inst.AccountMetaSlice[2]))
+						accountsBranch.Child(ag_format.Meta("SysVarRent", inst.AccountMetaSlice[3]))
+					})
+				})
+		})
+}
+
+func (obj InitializeAccount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	return nil
+}
+func (obj *InitializeAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+// NewInitializeAccountInstruction declares a new InitializeAccount instruction with the provided parameters and accounts.
+func NewInitializeAccountInstruction(
+	// Accounts:
+	account ag_solanago.PublicKey,
+	mint ag_solanago.PublicKey,
+	owner ag_solanago.PublicKey,
+	SysVarRentPubkey ag_solanago.PublicKey) *InitializeAccount {
+	return NewInitializeAccountInstructionBuilder().
+		SetAccount(account).
+		SetMintAccount(mint).
+		SetOwnerAccount(owner).
+		SetSysVarRentPubkeyAccount(SysVarRentPubkey)
+}

--- a/programs/token2022/InitializeAccount2.go
+++ b/programs/token2022/InitializeAccount2.go
@@ -1,0 +1,193 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Like InitializeAccount, but the owner pubkey is passed via instruction data
+// rather than the accounts list. This variant may be preferable when using
+// Cross Program Invocation from an instruction that does not need the owner's
+// `AccountInfo` otherwise.
+type InitializeAccount2 struct {
+	// The new account's owner/multisignature.
+	Owner *ag_solanago.PublicKey
+
+	// [0] = [WRITE] account
+	// ··········· The account to initialize.
+	//
+	// [1] = [] mint
+	// ··········· The mint this account will be associated with.
+	//
+	// [2] = [] $(SysVarRentPubkey)
+	// ··········· Rent sysvar.
+	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+// NewInitializeAccount2InstructionBuilder creates a new `InitializeAccount2` instruction builder.
+func NewInitializeAccount2InstructionBuilder() *InitializeAccount2 {
+	nd := &InitializeAccount2{
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 3),
+	}
+	nd.AccountMetaSlice[2] = ag_solanago.Meta(ag_solanago.SysVarRentPubkey)
+	return nd
+}
+
+// SetOwner sets the "owner" parameter.
+// The new account's owner/multisignature.
+func (inst *InitializeAccount2) SetOwner(owner ag_solanago.PublicKey) *InitializeAccount2 {
+	inst.Owner = &owner
+	return inst
+}
+
+// SetAccount sets the "account" account.
+// The account to initialize.
+func (inst *InitializeAccount2) SetAccount(account ag_solanago.PublicKey) *InitializeAccount2 {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(account).WRITE()
+	return inst
+}
+
+// GetAccount gets the "account" account.
+// The account to initialize.
+func (inst *InitializeAccount2) GetAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+
+// SetMintAccount sets the "mint" account.
+// The mint this account will be associated with.
+func (inst *InitializeAccount2) SetMintAccount(mint ag_solanago.PublicKey) *InitializeAccount2 {
+	inst.AccountMetaSlice[1] = ag_solanago.Meta(mint)
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The mint this account will be associated with.
+func (inst *InitializeAccount2) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[1]
+}
+
+// SetSysVarRentPubkeyAccount sets the "$(SysVarRentPubkey)" account.
+// Rent sysvar.
+func (inst *InitializeAccount2) SetSysVarRentPubkeyAccount(SysVarRentPubkey ag_solanago.PublicKey) *InitializeAccount2 {
+	inst.AccountMetaSlice[2] = ag_solanago.Meta(SysVarRentPubkey)
+	return inst
+}
+
+// GetSysVarRentPubkeyAccount gets the "$(SysVarRentPubkey)" account.
+// Rent sysvar.
+func (inst *InitializeAccount2) GetSysVarRentPubkeyAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[2]
+}
+
+func (inst InitializeAccount2) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeAccount2),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst InitializeAccount2) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *InitializeAccount2) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Owner == nil {
+			return errors.New("Owner parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.AccountMetaSlice[0] == nil {
+			return errors.New("accounts.Account is not set")
+		}
+		if inst.AccountMetaSlice[1] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+		if inst.AccountMetaSlice[2] == nil {
+			return errors.New("accounts.SysVarRentPubkey is not set")
+		}
+	}
+	return nil
+}
+
+func (inst *InitializeAccount2) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("InitializeAccount2")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("Owner", *inst.Owner))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("   account", inst.AccountMetaSlice[0]))
+						accountsBranch.Child(ag_format.Meta("      mint", inst.AccountMetaSlice[1]))
+						accountsBranch.Child(ag_format.Meta("SysVarRent", inst.AccountMetaSlice[2]))
+					})
+				})
+		})
+}
+
+func (obj InitializeAccount2) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Owner` param:
+	err = encoder.Encode(obj.Owner)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *InitializeAccount2) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Owner`:
+	err = decoder.Decode(&obj.Owner)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewInitializeAccount2Instruction declares a new InitializeAccount2 instruction with the provided parameters and accounts.
+func NewInitializeAccount2Instruction(
+	// Parameters:
+	owner ag_solanago.PublicKey,
+	// Accounts:
+	account ag_solanago.PublicKey,
+	mint ag_solanago.PublicKey,
+	SysVarRentPubkey ag_solanago.PublicKey) *InitializeAccount2 {
+	return NewInitializeAccount2InstructionBuilder().
+		SetOwner(owner).
+		SetAccount(account).
+		SetMintAccount(mint).
+		SetSysVarRentPubkeyAccount(SysVarRentPubkey)
+}

--- a/programs/token2022/InitializeAccount2_test.go
+++ b/programs/token2022/InitializeAccount2_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+)
+
+func TestEncodeDecode_InitializeAccount2(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("InitializeAccount2"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(InitializeAccount2)
+				fu.Fuzz(params)
+				params.AccountMetaSlice = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(InitializeAccount2)
+				err = decodeT(got, buf.Bytes())
+				got.AccountMetaSlice = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/InitializeAccount3.go
+++ b/programs/token2022/InitializeAccount3.go
@@ -1,0 +1,167 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Like InitializeAccount2, but does not require the Rent sysvar to be provided.
+type InitializeAccount3 struct {
+	// The new account's owner/multisignature.
+	Owner *ag_solanago.PublicKey
+
+	// [0] = [WRITE] account
+	// ··········· The account to initialize.
+	//
+	// [1] = [] mint
+	// ··········· The mint this account will be associated with.
+	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+// NewInitializeAccount3InstructionBuilder creates a new `InitializeAccount3` instruction builder.
+func NewInitializeAccount3InstructionBuilder() *InitializeAccount3 {
+	nd := &InitializeAccount3{
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 2),
+	}
+	return nd
+}
+
+// SetOwner sets the "owner" parameter.
+// The new account's owner/multisignature.
+func (inst *InitializeAccount3) SetOwner(owner ag_solanago.PublicKey) *InitializeAccount3 {
+	inst.Owner = &owner
+	return inst
+}
+
+// SetAccount sets the "account" account.
+// The account to initialize.
+func (inst *InitializeAccount3) SetAccount(account ag_solanago.PublicKey) *InitializeAccount3 {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(account).WRITE()
+	return inst
+}
+
+// GetAccount gets the "account" account.
+// The account to initialize.
+func (inst *InitializeAccount3) GetAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+
+// SetMintAccount sets the "mint" account.
+// The mint this account will be associated with.
+func (inst *InitializeAccount3) SetMintAccount(mint ag_solanago.PublicKey) *InitializeAccount3 {
+	inst.AccountMetaSlice[1] = ag_solanago.Meta(mint)
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The mint this account will be associated with.
+func (inst *InitializeAccount3) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[1]
+}
+
+func (inst InitializeAccount3) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeAccount3),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst InitializeAccount3) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *InitializeAccount3) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Owner == nil {
+			return errors.New("Owner parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.AccountMetaSlice[0] == nil {
+			return errors.New("accounts.Account is not set")
+		}
+		if inst.AccountMetaSlice[1] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+	}
+	return nil
+}
+
+func (inst *InitializeAccount3) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("InitializeAccount3")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("Owner", *inst.Owner))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("account", inst.AccountMetaSlice[0]))
+						accountsBranch.Child(ag_format.Meta("   mint", inst.AccountMetaSlice[1]))
+					})
+				})
+		})
+}
+
+func (obj InitializeAccount3) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Owner` param:
+	err = encoder.Encode(obj.Owner)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *InitializeAccount3) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Owner`:
+	err = decoder.Decode(&obj.Owner)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewInitializeAccount3Instruction declares a new InitializeAccount3 instruction with the provided parameters and accounts.
+func NewInitializeAccount3Instruction(
+	// Parameters:
+	owner ag_solanago.PublicKey,
+	// Accounts:
+	account ag_solanago.PublicKey,
+	mint ag_solanago.PublicKey) *InitializeAccount3 {
+	return NewInitializeAccount3InstructionBuilder().
+		SetOwner(owner).
+		SetAccount(account).
+		SetMintAccount(mint)
+}

--- a/programs/token2022/InitializeAccount3_test.go
+++ b/programs/token2022/InitializeAccount3_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+)
+
+func TestEncodeDecode_InitializeAccount3(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("InitializeAccount3"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(InitializeAccount3)
+				fu.Fuzz(params)
+				params.AccountMetaSlice = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(InitializeAccount3)
+				err = decodeT(got, buf.Bytes())
+				got.AccountMetaSlice = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/InitializeAccount_test.go
+++ b/programs/token2022/InitializeAccount_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+)
+
+func TestEncodeDecode_InitializeAccount(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("InitializeAccount"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(InitializeAccount)
+				fu.Fuzz(params)
+				params.AccountMetaSlice = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(InitializeAccount)
+				err = decodeT(got, buf.Bytes())
+				got.AccountMetaSlice = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/InitializeMint.go
+++ b/programs/token2022/InitializeMint.go
@@ -1,0 +1,245 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Initializes a new mint and optionally deposits all the newly minted
+// tokens in an account.
+//
+// The `InitializeMint` instruction requires no signers and MUST be
+// included within the same Transaction as the system program's
+// `CreateAccount` instruction that creates the account being initialized.
+// Otherwise another party can acquire ownership of the uninitialized
+// account.
+type InitializeMint struct {
+	// Number of base 10 digits to the right of the decimal place.
+	Decimals *uint8
+
+	// The authority/multisignature to mint tokens.
+	MintAuthority *ag_solanago.PublicKey
+
+	// The freeze authority/multisignature of the mint.
+	FreezeAuthority *ag_solanago.PublicKey `bin:"optional"`
+
+	// [0] = [WRITE] mint
+	// ··········· The mint to initialize.
+	//
+	// [1] = [] $(SysVarRentPubkey)
+	// ··········· Rent sysvar.
+	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+// NewInitializeMintInstructionBuilder creates a new `InitializeMint` instruction builder.
+func NewInitializeMintInstructionBuilder() *InitializeMint {
+	nd := &InitializeMint{
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 2),
+	}
+	nd.AccountMetaSlice[1] = ag_solanago.Meta(ag_solanago.SysVarRentPubkey)
+	return nd
+}
+
+// SetDecimals sets the "decimals" parameter.
+// Number of base 10 digits to the right of the decimal place.
+func (inst *InitializeMint) SetDecimals(decimals uint8) *InitializeMint {
+	inst.Decimals = &decimals
+	return inst
+}
+
+// SetMintAuthority sets the "mint_authority" parameter.
+// The authority/multisignature to mint tokens.
+func (inst *InitializeMint) SetMintAuthority(mint_authority ag_solanago.PublicKey) *InitializeMint {
+	inst.MintAuthority = &mint_authority
+	return inst
+}
+
+// SetFreezeAuthority sets the "freeze_authority" parameter.
+// The freeze authority/multisignature of the mint.
+func (inst *InitializeMint) SetFreezeAuthority(freeze_authority ag_solanago.PublicKey) *InitializeMint {
+	inst.FreezeAuthority = &freeze_authority
+	return inst
+}
+
+// SetMintAccount sets the "mint" account.
+// The mint to initialize.
+func (inst *InitializeMint) SetMintAccount(mint ag_solanago.PublicKey) *InitializeMint {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(mint).WRITE()
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The mint to initialize.
+func (inst *InitializeMint) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+
+// SetSysVarRentPubkeyAccount sets the "$(SysVarRentPubkey)" account.
+// Rent sysvar.
+func (inst *InitializeMint) SetSysVarRentPubkeyAccount(SysVarRentPubkey ag_solanago.PublicKey) *InitializeMint {
+	inst.AccountMetaSlice[1] = ag_solanago.Meta(SysVarRentPubkey)
+	return inst
+}
+
+// GetSysVarRentPubkeyAccount gets the "$(SysVarRentPubkey)" account.
+// Rent sysvar.
+func (inst *InitializeMint) GetSysVarRentPubkeyAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[1]
+}
+
+func (inst InitializeMint) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMint),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst InitializeMint) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *InitializeMint) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Decimals == nil {
+			return errors.New("Decimals parameter is not set")
+		}
+		if inst.MintAuthority == nil {
+			return errors.New("MintAuthority parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.AccountMetaSlice[0] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+		if inst.AccountMetaSlice[1] == nil {
+			return errors.New("accounts.SysVarRentPubkey is not set")
+		}
+	}
+	return nil
+}
+
+func (inst *InitializeMint) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("InitializeMint")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("             Decimals", *inst.Decimals))
+						paramsBranch.Child(ag_format.Param("        MintAuthority", *inst.MintAuthority))
+						paramsBranch.Child(ag_format.Param("FreezeAuthority (OPT)", inst.FreezeAuthority))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("      mint", inst.AccountMetaSlice[0]))
+						accountsBranch.Child(ag_format.Meta("SysVarRent", inst.AccountMetaSlice[1]))
+					})
+				})
+		})
+}
+
+func (obj InitializeMint) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Decimals` param:
+	err = encoder.Encode(obj.Decimals)
+	if err != nil {
+		return err
+	}
+	// Serialize `MintAuthority` param:
+	err = encoder.Encode(obj.MintAuthority)
+	if err != nil {
+		return err
+	}
+	// Serialize `FreezeAuthority` param (optional):
+	{
+		if obj.FreezeAuthority == nil {
+			err = encoder.WriteBool(false)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = encoder.WriteBool(true)
+			if err != nil {
+				return err
+			}
+			err = encoder.Encode(obj.FreezeAuthority)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+func (obj *InitializeMint) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Decimals`:
+	err = decoder.Decode(&obj.Decimals)
+	if err != nil {
+		return err
+	}
+	// Deserialize `MintAuthority`:
+	err = decoder.Decode(&obj.MintAuthority)
+	if err != nil {
+		return err
+	}
+	// Deserialize `FreezeAuthority` (optional):
+	{
+		ok, err := decoder.ReadBool()
+		if err != nil {
+			return err
+		}
+		if ok {
+			err = decoder.Decode(&obj.FreezeAuthority)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// NewInitializeMintInstruction declares a new InitializeMint instruction with the provided parameters and accounts.
+func NewInitializeMintInstruction(
+	// Parameters:
+	decimals uint8,
+	mint_authority ag_solanago.PublicKey,
+	freeze_authority ag_solanago.PublicKey,
+	// Accounts:
+	mint ag_solanago.PublicKey,
+	SysVarRentPubkey ag_solanago.PublicKey) *InitializeMint {
+	return NewInitializeMintInstructionBuilder().
+		SetDecimals(decimals).
+		SetMintAuthority(mint_authority).
+		SetFreezeAuthority(freeze_authority).
+		SetMintAccount(mint).
+		SetSysVarRentPubkeyAccount(SysVarRentPubkey)
+}

--- a/programs/token2022/InitializeMint2.go
+++ b/programs/token2022/InitializeMint2.go
@@ -1,0 +1,215 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Like InitializeMint, but does not require the Rent sysvar to be provided.
+type InitializeMint2 struct {
+	// Number of base 10 digits to the right of the decimal place.
+	Decimals *uint8
+
+	// The authority/multisignature to mint tokens.
+	MintAuthority *ag_solanago.PublicKey
+
+	// The freeze authority/multisignature of the mint.
+	FreezeAuthority *ag_solanago.PublicKey `bin:"optional"`
+
+	// [0] = [WRITE] mint
+	// ··········· The mint to initialize.
+	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+// NewInitializeMint2InstructionBuilder creates a new `InitializeMint2` instruction builder.
+func NewInitializeMint2InstructionBuilder() *InitializeMint2 {
+	nd := &InitializeMint2{
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 1),
+	}
+	return nd
+}
+
+// SetDecimals sets the "decimals" parameter.
+// Number of base 10 digits to the right of the decimal place.
+func (inst *InitializeMint2) SetDecimals(decimals uint8) *InitializeMint2 {
+	inst.Decimals = &decimals
+	return inst
+}
+
+// SetMintAuthority sets the "mint_authority" parameter.
+// The authority/multisignature to mint tokens.
+func (inst *InitializeMint2) SetMintAuthority(mint_authority ag_solanago.PublicKey) *InitializeMint2 {
+	inst.MintAuthority = &mint_authority
+	return inst
+}
+
+// SetFreezeAuthority sets the "freeze_authority" parameter.
+// The freeze authority/multisignature of the mint.
+func (inst *InitializeMint2) SetFreezeAuthority(freeze_authority ag_solanago.PublicKey) *InitializeMint2 {
+	inst.FreezeAuthority = &freeze_authority
+	return inst
+}
+
+// SetMintAccount sets the "mint" account.
+// The mint to initialize.
+func (inst *InitializeMint2) SetMintAccount(mint ag_solanago.PublicKey) *InitializeMint2 {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(mint).WRITE()
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The mint to initialize.
+func (inst *InitializeMint2) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+
+func (inst InitializeMint2) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMint2),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst InitializeMint2) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *InitializeMint2) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Decimals == nil {
+			return errors.New("Decimals parameter is not set")
+		}
+		if inst.MintAuthority == nil {
+			return errors.New("MintAuthority parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.AccountMetaSlice[0] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+	}
+	return nil
+}
+
+func (inst *InitializeMint2) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("InitializeMint2")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("             Decimals", *inst.Decimals))
+						paramsBranch.Child(ag_format.Param("        MintAuthority", *inst.MintAuthority))
+						paramsBranch.Child(ag_format.Param("FreezeAuthority (OPT)", inst.FreezeAuthority))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("mint", inst.AccountMetaSlice[0]))
+					})
+				})
+		})
+}
+
+func (obj InitializeMint2) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Decimals` param:
+	err = encoder.Encode(obj.Decimals)
+	if err != nil {
+		return err
+	}
+	// Serialize `MintAuthority` param:
+	err = encoder.Encode(obj.MintAuthority)
+	if err != nil {
+		return err
+	}
+	// Serialize `FreezeAuthority` param (optional):
+	{
+		if obj.FreezeAuthority == nil {
+			err = encoder.WriteBool(false)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = encoder.WriteBool(true)
+			if err != nil {
+				return err
+			}
+			err = encoder.Encode(obj.FreezeAuthority)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+func (obj *InitializeMint2) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Decimals`:
+	err = decoder.Decode(&obj.Decimals)
+	if err != nil {
+		return err
+	}
+	// Deserialize `MintAuthority`:
+	err = decoder.Decode(&obj.MintAuthority)
+	if err != nil {
+		return err
+	}
+	// Deserialize `FreezeAuthority` (optional):
+	{
+		ok, err := decoder.ReadBool()
+		if err != nil {
+			return err
+		}
+		if ok {
+			err = decoder.Decode(&obj.FreezeAuthority)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// NewInitializeMint2Instruction declares a new InitializeMint2 instruction with the provided parameters and accounts.
+func NewInitializeMint2Instruction(
+	// Parameters:
+	decimals uint8,
+	mint_authority ag_solanago.PublicKey,
+	freeze_authority ag_solanago.PublicKey,
+	// Accounts:
+	mint ag_solanago.PublicKey) *InitializeMint2 {
+	return NewInitializeMint2InstructionBuilder().
+		SetDecimals(decimals).
+		SetMintAuthority(mint_authority).
+		SetFreezeAuthority(freeze_authority).
+		SetMintAccount(mint)
+}

--- a/programs/token2022/InitializeMint2_test.go
+++ b/programs/token2022/InitializeMint2_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+)
+
+func TestEncodeDecode_InitializeMint2(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("InitializeMint2"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(InitializeMint2)
+				fu.Fuzz(params)
+				params.AccountMetaSlice = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(InitializeMint2)
+				err = decodeT(got, buf.Bytes())
+				got.AccountMetaSlice = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/InitializeMint_test.go
+++ b/programs/token2022/InitializeMint_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+)
+
+func TestEncodeDecode_InitializeMint(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("InitializeMint"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(InitializeMint)
+				fu.Fuzz(params)
+				params.AccountMetaSlice = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(InitializeMint)
+				err = decodeT(got, buf.Bytes())
+				got.AccountMetaSlice = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/InitializeMultisig.go
+++ b/programs/token2022/InitializeMultisig.go
@@ -1,0 +1,225 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Initializes a multisignature account with N provided signers.
+//
+// Multisignature accounts can used in place of any single owner/delegate
+// accounts in any token instruction that require an owner/delegate to be
+// present.  The variant field represents the number of signers (M)
+// required to validate this multisignature account.
+//
+// The `InitializeMultisig` instruction requires no signers and MUST be
+// included within the same Transaction as the system program's
+// `CreateAccount` instruction that creates the account being initialized.
+// Otherwise another party can acquire ownership of the uninitialized
+// account.
+type InitializeMultisig struct {
+	// The number of signers (M) required to validate this multisignature
+	// account.
+	M *uint8
+
+	// [0] = [WRITE] account
+	// ··········· The multisignature account to initialize.
+	//
+	// [1] = [] $(SysVarRentPubkey)
+	// ··········· Rent sysvar.
+	//
+	// [2...] = [SIGNER] signers
+	// ··········· ..2+N The signer accounts, must equal to N where 1 <= N <=11
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *InitializeMultisig) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(2)
+	return nil
+}
+
+func (slice InitializeMultisig) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewInitializeMultisigInstructionBuilder creates a new `InitializeMultisig` instruction builder.
+func NewInitializeMultisigInstructionBuilder() *InitializeMultisig {
+	nd := &InitializeMultisig{
+		Accounts: make(ag_solanago.AccountMetaSlice, 2),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	nd.Accounts[1] = ag_solanago.Meta(ag_solanago.SysVarRentPubkey)
+	return nd
+}
+
+// SetM sets the "m" parameter.
+// The number of signers (M) required to validate this multisignature
+// account.
+func (inst *InitializeMultisig) SetM(m uint8) *InitializeMultisig {
+	inst.M = &m
+	return inst
+}
+
+// SetAccount sets the "account" account.
+// The multisignature account to initialize.
+func (inst *InitializeMultisig) SetAccount(account ag_solanago.PublicKey) *InitializeMultisig {
+	inst.Accounts[0] = ag_solanago.Meta(account).WRITE()
+	return inst
+}
+
+// GetAccount gets the "account" account.
+// The multisignature account to initialize.
+func (inst *InitializeMultisig) GetAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetSysVarRentPubkeyAccount sets the "$(SysVarRentPubkey)" account.
+// Rent sysvar.
+func (inst *InitializeMultisig) SetSysVarRentPubkeyAccount(SysVarRentPubkey ag_solanago.PublicKey) *InitializeMultisig {
+	inst.Accounts[1] = ag_solanago.Meta(SysVarRentPubkey)
+	return inst
+}
+
+// GetSysVarRentPubkeyAccount gets the "$(SysVarRentPubkey)" account.
+// Rent sysvar.
+func (inst *InitializeMultisig) GetSysVarRentPubkeyAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// AddSigners adds the "signers" accounts.
+// ..2+N The signer accounts, must equal to N where 1 <= N <=11
+func (inst *InitializeMultisig) AddSigners(signers ...ag_solanago.PublicKey) *InitializeMultisig {
+	for _, signer := range signers {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+func (inst InitializeMultisig) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMultisig),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst InitializeMultisig) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *InitializeMultisig) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.M == nil {
+			return errors.New("M parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return fmt.Errorf("accounts.Account is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return fmt.Errorf("accounts.SysVarRentPubkey is not set")
+		}
+		if len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *InitializeMultisig) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("InitializeMultisig")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("M", *inst.M))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("   account", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("SysVarRent", inst.Accounts[1]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj InitializeMultisig) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `M` param:
+	err = encoder.Encode(obj.M)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *InitializeMultisig) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `M`:
+	err = decoder.Decode(&obj.M)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewInitializeMultisigInstruction declares a new InitializeMultisig instruction with the provided parameters and accounts.
+func NewInitializeMultisigInstruction(
+	// Parameters:
+	m uint8,
+	// Accounts:
+	account ag_solanago.PublicKey,
+	SysVarRentPubkey ag_solanago.PublicKey,
+	signers []ag_solanago.PublicKey,
+) *InitializeMultisig {
+	return NewInitializeMultisigInstructionBuilder().
+		SetM(m).
+		SetAccount(account).
+		SetSysVarRentPubkeyAccount(SysVarRentPubkey).
+		AddSigners(signers...)
+}

--- a/programs/token2022/InitializeMultisig2.go
+++ b/programs/token2022/InitializeMultisig2.go
@@ -1,0 +1,189 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Like InitializeMultisig, but does not require the Rent sysvar to be provided.
+type InitializeMultisig2 struct {
+	// The number of signers (M) required to validate this multisignature account.
+	M *uint8
+
+	// [0] = [WRITE] account
+	// ··········· The multisignature account to initialize.
+	//
+	// [1] = [SIGNER] signers
+	// ··········· The signer accounts, must equal to N where 1 <= N <= 11.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *InitializeMultisig2) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(1)
+	return nil
+}
+
+func (slice InitializeMultisig2) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewInitializeMultisig2InstructionBuilder creates a new `InitializeMultisig2` instruction builder.
+func NewInitializeMultisig2InstructionBuilder() *InitializeMultisig2 {
+	nd := &InitializeMultisig2{
+		Accounts: make(ag_solanago.AccountMetaSlice, 1),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetM sets the "m" parameter.
+// The number of signers (M) required to validate this multisignature account.
+func (inst *InitializeMultisig2) SetM(m uint8) *InitializeMultisig2 {
+	inst.M = &m
+	return inst
+}
+
+// SetAccount sets the "account" account.
+// The multisignature account to initialize.
+func (inst *InitializeMultisig2) SetAccount(account ag_solanago.PublicKey) *InitializeMultisig2 {
+	inst.Accounts[0] = ag_solanago.Meta(account).WRITE()
+	return inst
+}
+
+// GetAccount gets the "account" account.
+// The multisignature account to initialize.
+func (inst *InitializeMultisig2) GetAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// AddSigners adds the "signers" accounts.
+// The signer accounts, must equal to N where 1 <= N <= 11.
+func (inst *InitializeMultisig2) AddSigners(signers ...ag_solanago.PublicKey) *InitializeMultisig2 {
+	for _, signer := range signers {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+func (inst InitializeMultisig2) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeMultisig2),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst InitializeMultisig2) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *InitializeMultisig2) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.M == nil {
+			return errors.New("M parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Account is not set")
+		}
+		if len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *InitializeMultisig2) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("InitializeMultisig2")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("M", *inst.M))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("account", inst.Accounts[0]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj InitializeMultisig2) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `M` param:
+	err = encoder.Encode(obj.M)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *InitializeMultisig2) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `M`:
+	err = decoder.Decode(&obj.M)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewInitializeMultisig2Instruction declares a new InitializeMultisig2 instruction with the provided parameters and accounts.
+func NewInitializeMultisig2Instruction(
+	// Parameters:
+	m uint8,
+	// Accounts:
+	account ag_solanago.PublicKey,
+	signers []ag_solanago.PublicKey,
+) *InitializeMultisig2 {
+	return NewInitializeMultisig2InstructionBuilder().
+		SetM(m).
+		SetAccount(account).
+		AddSigners(signers...)
+}

--- a/programs/token2022/InitializeMultisig2_test.go
+++ b/programs/token2022/InitializeMultisig2_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_InitializeMultisig2(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("InitializeMultisig2"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(InitializeMultisig2)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(InitializeMultisig2)
+				err = decodeT(got, buf.Bytes())
+				params.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/InitializeMultisig_test.go
+++ b/programs/token2022/InitializeMultisig_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_InitializeMultisig(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("InitializeMultisig"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(InitializeMultisig)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(InitializeMultisig)
+				err = decodeT(got, buf.Bytes())
+				got.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/MintTo.go
+++ b/programs/token2022/MintTo.go
@@ -1,0 +1,230 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Mints new tokens to an account.  The native mint does not support
+// minting.
+type MintTo struct {
+	// The amount of new tokens to mint.
+	Amount *uint64
+
+	// [0] = [WRITE] mint
+	// ··········· The mint.
+	//
+	// [1] = [WRITE] destination
+	// ··········· The account to mint tokens to.
+	//
+	// [2] = [] authority
+	// ··········· The mint's minting authority.
+	//
+	// [3...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *MintTo) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(3)
+	return nil
+}
+
+func (slice MintTo) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewMintToInstructionBuilder creates a new `MintTo` instruction builder.
+func NewMintToInstructionBuilder() *MintTo {
+	nd := &MintTo{
+		Accounts: make(ag_solanago.AccountMetaSlice, 3),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetAmount sets the "amount" parameter.
+// The amount of new tokens to mint.
+func (inst *MintTo) SetAmount(amount uint64) *MintTo {
+	inst.Amount = &amount
+	return inst
+}
+
+// SetMintAccount sets the "mint" account.
+// The mint.
+func (inst *MintTo) SetMintAccount(mint ag_solanago.PublicKey) *MintTo {
+	inst.Accounts[0] = ag_solanago.Meta(mint).WRITE()
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The mint.
+func (inst *MintTo) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetDestinationAccount sets the "destination" account.
+// The account to mint tokens to.
+func (inst *MintTo) SetDestinationAccount(destination ag_solanago.PublicKey) *MintTo {
+	inst.Accounts[1] = ag_solanago.Meta(destination).WRITE()
+	return inst
+}
+
+// GetDestinationAccount gets the "destination" account.
+// The account to mint tokens to.
+func (inst *MintTo) GetDestinationAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetAuthorityAccount sets the "authority" account.
+// The mint's minting authority.
+func (inst *MintTo) SetAuthorityAccount(authority ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *MintTo {
+	inst.Accounts[2] = ag_solanago.Meta(authority)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[2].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetAuthorityAccount gets the "authority" account.
+// The mint's minting authority.
+func (inst *MintTo) GetAuthorityAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+func (inst MintTo) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_MintTo),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst MintTo) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *MintTo) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Amount == nil {
+			return errors.New("Amount parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.Destination is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return errors.New("accounts.Authority is not set")
+		}
+		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *MintTo) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("MintTo")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("Amount", *inst.Amount))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("       mint", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("destination", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("  authority", inst.Accounts[2]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj MintTo) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Amount` param:
+	err = encoder.Encode(obj.Amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *MintTo) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Amount`:
+	err = decoder.Decode(&obj.Amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewMintToInstruction declares a new MintTo instruction with the provided parameters and accounts.
+func NewMintToInstruction(
+	// Parameters:
+	amount uint64,
+	// Accounts:
+	mint ag_solanago.PublicKey,
+	destination ag_solanago.PublicKey,
+	authority ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *MintTo {
+	return NewMintToInstructionBuilder().
+		SetAmount(amount).
+		SetMintAccount(mint).
+		SetDestinationAccount(destination).
+		SetAuthorityAccount(authority, multisigSigners...)
+}

--- a/programs/token2022/MintToChecked.go
+++ b/programs/token2022/MintToChecked.go
@@ -1,0 +1,259 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Mints new tokens to an account.  The native mint does not support minting.
+//
+// This instruction differs from MintTo in that the decimals value is
+// checked by the caller.  This may be useful when creating transactions
+// offline or within a hardware wallet.
+type MintToChecked struct {
+	// The amount of new tokens to mint.
+	Amount *uint64
+
+	// Expected number of base 10 digits to the right of the decimal place.
+	Decimals *uint8
+
+	// [0] = [WRITE] mint
+	// ··········· The mint.
+	//
+	// [1] = [WRITE] destination
+	// ··········· The account to mint tokens to.
+	//
+	// [2] = [] authority
+	// ··········· The mint's minting authority.
+	//
+	// [3...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *MintToChecked) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(3)
+	return nil
+}
+
+func (slice MintToChecked) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewMintToCheckedInstructionBuilder creates a new `MintToChecked` instruction builder.
+func NewMintToCheckedInstructionBuilder() *MintToChecked {
+	nd := &MintToChecked{
+		Accounts: make(ag_solanago.AccountMetaSlice, 3),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetAmount sets the "amount" parameter.
+// The amount of new tokens to mint.
+func (inst *MintToChecked) SetAmount(amount uint64) *MintToChecked {
+	inst.Amount = &amount
+	return inst
+}
+
+// SetDecimals sets the "decimals" parameter.
+// Expected number of base 10 digits to the right of the decimal place.
+func (inst *MintToChecked) SetDecimals(decimals uint8) *MintToChecked {
+	inst.Decimals = &decimals
+	return inst
+}
+
+// SetMintAccount sets the "mint" account.
+// The mint.
+func (inst *MintToChecked) SetMintAccount(mint ag_solanago.PublicKey) *MintToChecked {
+	inst.Accounts[0] = ag_solanago.Meta(mint).WRITE()
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The mint.
+func (inst *MintToChecked) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetDestinationAccount sets the "destination" account.
+// The account to mint tokens to.
+func (inst *MintToChecked) SetDestinationAccount(destination ag_solanago.PublicKey) *MintToChecked {
+	inst.Accounts[1] = ag_solanago.Meta(destination).WRITE()
+	return inst
+}
+
+// GetDestinationAccount gets the "destination" account.
+// The account to mint tokens to.
+func (inst *MintToChecked) GetDestinationAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetAuthorityAccount sets the "authority" account.
+// The mint's minting authority.
+func (inst *MintToChecked) SetAuthorityAccount(authority ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *MintToChecked {
+	inst.Accounts[2] = ag_solanago.Meta(authority)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[2].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetAuthorityAccount gets the "authority" account.
+// The mint's minting authority.
+func (inst *MintToChecked) GetAuthorityAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+func (inst MintToChecked) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_MintToChecked),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst MintToChecked) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *MintToChecked) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Amount == nil {
+			return errors.New("Amount parameter is not set")
+		}
+		if inst.Decimals == nil {
+			return errors.New("Decimals parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.Destination is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return errors.New("accounts.Authority is not set")
+		}
+		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *MintToChecked) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("MintToChecked")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("  Amount", *inst.Amount))
+						paramsBranch.Child(ag_format.Param("Decimals", *inst.Decimals))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("       mint", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("destination", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("  authority", inst.Accounts[2]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj MintToChecked) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Amount` param:
+	err = encoder.Encode(obj.Amount)
+	if err != nil {
+		return err
+	}
+	// Serialize `Decimals` param:
+	err = encoder.Encode(obj.Decimals)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *MintToChecked) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Amount`:
+	err = decoder.Decode(&obj.Amount)
+	if err != nil {
+		return err
+	}
+	// Deserialize `Decimals`:
+	err = decoder.Decode(&obj.Decimals)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewMintToCheckedInstruction declares a new MintToChecked instruction with the provided parameters and accounts.
+func NewMintToCheckedInstruction(
+	// Parameters:
+	amount uint64,
+	decimals uint8,
+	// Accounts:
+	mint ag_solanago.PublicKey,
+	destination ag_solanago.PublicKey,
+	authority ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *MintToChecked {
+	return NewMintToCheckedInstructionBuilder().
+		SetAmount(amount).
+		SetDecimals(decimals).
+		SetMintAccount(mint).
+		SetDestinationAccount(destination).
+		SetAuthorityAccount(authority, multisigSigners...)
+}

--- a/programs/token2022/MintToChecked_test.go
+++ b/programs/token2022/MintToChecked_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_MintToChecked(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("MintToChecked"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(MintToChecked)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(MintToChecked)
+				err = decodeT(got, buf.Bytes())
+				params.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/MintTo_test.go
+++ b/programs/token2022/MintTo_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_MintTo(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("MintTo"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(MintTo)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(MintTo)
+				err = decodeT(got, buf.Bytes())
+				params.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/Revoke.go
+++ b/programs/token2022/Revoke.go
@@ -1,0 +1,176 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Revokes the delegate's authority.
+type Revoke struct {
+
+	// [0] = [WRITE] source
+	// ··········· The source account.
+	//
+	// [1] = [] owner
+	// ··········· The source account's owner.
+	//
+	// [2...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *Revoke) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(2)
+	return nil
+}
+
+func (slice Revoke) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewRevokeInstructionBuilder creates a new `Revoke` instruction builder.
+func NewRevokeInstructionBuilder() *Revoke {
+	nd := &Revoke{
+		Accounts: make(ag_solanago.AccountMetaSlice, 2),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetSourceAccount sets the "source" account.
+// The source account.
+func (inst *Revoke) SetSourceAccount(source ag_solanago.PublicKey) *Revoke {
+	inst.Accounts[0] = ag_solanago.Meta(source).WRITE()
+	return inst
+}
+
+// GetSourceAccount gets the "source" account.
+// The source account.
+func (inst *Revoke) GetSourceAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetOwnerAccount sets the "owner" account.
+// The source account's owner.
+func (inst *Revoke) SetOwnerAccount(owner ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *Revoke {
+	inst.Accounts[1] = ag_solanago.Meta(owner)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[1].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetOwnerAccount gets the "owner" account.
+// The source account's owner.
+func (inst *Revoke) GetOwnerAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+func (inst Revoke) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_Revoke),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst Revoke) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *Revoke) Validate() error {
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Source is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.Owner is not set")
+		}
+		if !inst.Accounts[1].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *Revoke) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("Revoke")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("source", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta(" owner", inst.Accounts[1]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj Revoke) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	return nil
+}
+func (obj *Revoke) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+// NewRevokeInstruction declares a new Revoke instruction with the provided parameters and accounts.
+func NewRevokeInstruction(
+	// Accounts:
+	source ag_solanago.PublicKey,
+	owner ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *Revoke {
+	return NewRevokeInstructionBuilder().
+		SetSourceAccount(source).
+		SetOwnerAccount(owner, multisigSigners...)
+}

--- a/programs/token2022/Revoke_test.go
+++ b/programs/token2022/Revoke_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_Revoke(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("Revoke"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(Revoke)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(Revoke)
+				err = decodeT(got, buf.Bytes())
+				params.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/SetAuthority.go
+++ b/programs/token2022/SetAuthority.go
@@ -1,0 +1,251 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Sets a new authority of a mint or account.
+type SetAuthority struct {
+	// The type of authority to update.
+	AuthorityType *AuthorityType
+
+	// The new authority.
+	NewAuthority *ag_solanago.PublicKey `bin:"optional"`
+
+	// [0] = [WRITE] subject
+	// ··········· The mint or account to change the authority of.
+	//
+	// [1] = [] authority
+	// ··········· The current authority of the mint or account.
+	//
+	// [2...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *SetAuthority) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(2)
+	return nil
+}
+
+func (slice SetAuthority) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewSetAuthorityInstructionBuilder creates a new `SetAuthority` instruction builder.
+func NewSetAuthorityInstructionBuilder() *SetAuthority {
+	nd := &SetAuthority{
+		Accounts: make(ag_solanago.AccountMetaSlice, 2),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetAuthorityType sets the "authority_type" parameter.
+// The type of authority to update.
+func (inst *SetAuthority) SetAuthorityType(authority_type AuthorityType) *SetAuthority {
+	inst.AuthorityType = &authority_type
+	return inst
+}
+
+// SetNewAuthority sets the "new_authority" parameter.
+// The new authority.
+func (inst *SetAuthority) SetNewAuthority(new_authority ag_solanago.PublicKey) *SetAuthority {
+	inst.NewAuthority = &new_authority
+	return inst
+}
+
+// SetSubjectAccount sets the "subject" account.
+// The mint or account to change the authority of.
+func (inst *SetAuthority) SetSubjectAccount(subject ag_solanago.PublicKey) *SetAuthority {
+	inst.Accounts[0] = ag_solanago.Meta(subject).WRITE()
+	return inst
+}
+
+// GetSubjectAccount gets the "subject" account.
+// The mint or account to change the authority of.
+func (inst *SetAuthority) GetSubjectAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetAuthorityAccount sets the "authority" account.
+// The current authority of the mint or account.
+func (inst *SetAuthority) SetAuthorityAccount(authority ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *SetAuthority {
+	inst.Accounts[1] = ag_solanago.Meta(authority)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[1].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetAuthorityAccount gets the "authority" account.
+// The current authority of the mint or account.
+func (inst *SetAuthority) GetAuthorityAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+func (inst SetAuthority) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_SetAuthority),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst SetAuthority) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *SetAuthority) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.AuthorityType == nil {
+			return errors.New("AuthorityType parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Subject is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.Authority is not set")
+		}
+		if !inst.Accounts[1].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *SetAuthority) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("SetAuthority")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("     AuthorityType", *inst.AuthorityType))
+						paramsBranch.Child(ag_format.Param("NewAuthority (OPT)", inst.NewAuthority))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("  subject", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("authority", inst.Accounts[1]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj SetAuthority) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `AuthorityType` param:
+	err = encoder.Encode(obj.AuthorityType)
+	if err != nil {
+		return err
+	}
+	// Serialize `NewAuthority` param (optional):
+	{
+		if obj.NewAuthority == nil {
+			err = encoder.WriteBool(false)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = encoder.WriteBool(true)
+			if err != nil {
+				return err
+			}
+			err = encoder.Encode(obj.NewAuthority)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+func (obj *SetAuthority) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `AuthorityType`:
+	err = decoder.Decode(&obj.AuthorityType)
+	if err != nil {
+		return err
+	}
+	// Deserialize `NewAuthority` (optional):
+	{
+		ok, err := decoder.ReadBool()
+		if err != nil {
+			return err
+		}
+		if ok {
+			err = decoder.Decode(&obj.NewAuthority)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// NewSetAuthorityInstruction declares a new SetAuthority instruction with the provided parameters and accounts.
+func NewSetAuthorityInstruction(
+	// Parameters:
+	authority_type AuthorityType,
+	new_authority ag_solanago.PublicKey,
+	// Accounts:
+	subject ag_solanago.PublicKey,
+	authority ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *SetAuthority {
+	return NewSetAuthorityInstructionBuilder().
+		SetAuthorityType(authority_type).
+		SetNewAuthority(new_authority).
+		SetSubjectAccount(subject).
+		SetAuthorityAccount(authority, multisigSigners...)
+}

--- a/programs/token2022/SetAuthority_test.go
+++ b/programs/token2022/SetAuthority_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_SetAuthority(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("SetAuthority"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(SetAuthority)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(SetAuthority)
+				err = decodeT(got, buf.Bytes())
+				params.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/SyncNative.go
+++ b/programs/token2022/SyncNative.go
@@ -1,0 +1,118 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Given a wrapped / native token account (a token account containing SOL)
+// updates its amount field based on the account's underlying `lamports`.
+// This is useful if a non-wrapped SOL account uses `system_instruction::transfer`
+// to move lamports to a wrapped token account, and needs to have its token
+// `amount` field updated.
+type SyncNative struct {
+
+	// [0] = [WRITE] tokenAccount
+	// ··········· The native token account to sync with its underlying lamports.
+	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+// NewSyncNativeInstructionBuilder creates a new `SyncNative` instruction builder.
+func NewSyncNativeInstructionBuilder() *SyncNative {
+	nd := &SyncNative{
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 1),
+	}
+	return nd
+}
+
+// SetTokenAccount sets the "tokenAccount" account.
+// The native token account to sync with its underlying lamports.
+func (inst *SyncNative) SetTokenAccount(tokenAccount ag_solanago.PublicKey) *SyncNative {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(tokenAccount).WRITE()
+	return inst
+}
+
+// GetTokenAccount gets the "tokenAccount" account.
+// The native token account to sync with its underlying lamports.
+func (inst *SyncNative) GetTokenAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+
+func (inst SyncNative) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_SyncNative),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst SyncNative) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *SyncNative) Validate() error {
+	// Check whether all (required) accounts are set:
+	{
+		if inst.AccountMetaSlice[0] == nil {
+			return errors.New("accounts.TokenAccount is not set")
+		}
+	}
+	return nil
+}
+
+func (inst *SyncNative) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("SyncNative")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("tokenAccount", inst.AccountMetaSlice[0]))
+					})
+				})
+		})
+}
+
+func (obj SyncNative) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	return nil
+}
+func (obj *SyncNative) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+// NewSyncNativeInstruction declares a new SyncNative instruction with the provided parameters and accounts.
+func NewSyncNativeInstruction(
+	// Accounts:
+	tokenAccount ag_solanago.PublicKey) *SyncNative {
+	return NewSyncNativeInstructionBuilder().
+		SetTokenAccount(tokenAccount)
+}

--- a/programs/token2022/SyncNative_test.go
+++ b/programs/token2022/SyncNative_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+)
+
+func TestEncodeDecode_SyncNative(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("SyncNative"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(SyncNative)
+				fu.Fuzz(params)
+				params.AccountMetaSlice = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(SyncNative)
+				err = decodeT(got, buf.Bytes())
+				got.AccountMetaSlice = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/ThawAccount.go
+++ b/programs/token2022/ThawAccount.go
@@ -1,0 +1,198 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Thaw a Frozen account using the Mint's freeze_authority (if set).
+type ThawAccount struct {
+
+	// [0] = [WRITE] account
+	// ··········· The account to thaw.
+	//
+	// [1] = [] mint
+	// ··········· The token mint.
+	//
+	// [2] = [] authority
+	// ··········· The mint freeze authority.
+	//
+	// [3...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *ThawAccount) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(3)
+	return nil
+}
+
+func (slice ThawAccount) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewThawAccountInstructionBuilder creates a new `ThawAccount` instruction builder.
+func NewThawAccountInstructionBuilder() *ThawAccount {
+	nd := &ThawAccount{
+		Accounts: make(ag_solanago.AccountMetaSlice, 3),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetAccount sets the "account" account.
+// The account to thaw.
+func (inst *ThawAccount) SetAccount(account ag_solanago.PublicKey) *ThawAccount {
+	inst.Accounts[0] = ag_solanago.Meta(account).WRITE()
+	return inst
+}
+
+// GetAccount gets the "account" account.
+// The account to thaw.
+func (inst *ThawAccount) GetAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetMintAccount sets the "mint" account.
+// The token mint.
+func (inst *ThawAccount) SetMintAccount(mint ag_solanago.PublicKey) *ThawAccount {
+	inst.Accounts[1] = ag_solanago.Meta(mint)
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The token mint.
+func (inst *ThawAccount) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetAuthorityAccount sets the "authority" account.
+// The mint freeze authority.
+func (inst *ThawAccount) SetAuthorityAccount(authority ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *ThawAccount {
+	inst.Accounts[2] = ag_solanago.Meta(authority)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[2].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetAuthorityAccount gets the "authority" account.
+// The mint freeze authority.
+func (inst *ThawAccount) GetAuthorityAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+func (inst ThawAccount) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_ThawAccount),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst ThawAccount) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *ThawAccount) Validate() error {
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Account is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return errors.New("accounts.Authority is not set")
+		}
+		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *ThawAccount) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("ThawAccount")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("  account", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("     mint", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("authority", inst.Accounts[2]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj ThawAccount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	return nil
+}
+func (obj *ThawAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+// NewThawAccountInstruction declares a new ThawAccount instruction with the provided parameters and accounts.
+func NewThawAccountInstruction(
+	// Accounts:
+	account ag_solanago.PublicKey,
+	mint ag_solanago.PublicKey,
+	authority ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *ThawAccount {
+	return NewThawAccountInstructionBuilder().
+		SetAccount(account).
+		SetMintAccount(mint).
+		SetAuthorityAccount(authority, multisigSigners...)
+}

--- a/programs/token2022/ThawAccount_test.go
+++ b/programs/token2022/ThawAccount_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_ThawAccount(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("ThawAccount"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(ThawAccount)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(ThawAccount)
+				err = decodeT(got, buf.Bytes())
+				params.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/Transfer.go
+++ b/programs/token2022/Transfer.go
@@ -1,0 +1,231 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Transfers tokens from one account to another either directly or via a
+// delegate.  If this account is associated with the native mint then equal
+// amounts of SOL and Tokens will be transferred to the destination
+// account.
+type Transfer struct {
+	// The amount of tokens to transfer.
+	Amount *uint64
+
+	// [0] = [WRITE] source
+	// ··········· The source account.
+	//
+	// [1] = [WRITE] destination
+	// ··········· The destination account.
+	//
+	// [2] = [] owner
+	// ··········· The source account owner/delegate.
+	//
+	// [3...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *Transfer) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(3)
+	return nil
+}
+
+func (slice Transfer) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewTransferInstructionBuilder creates a new `Transfer` instruction builder.
+func NewTransferInstructionBuilder() *Transfer {
+	nd := &Transfer{
+		Accounts: make(ag_solanago.AccountMetaSlice, 3),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetAmount sets the "amount" parameter.
+// The amount of tokens to transfer.
+func (inst *Transfer) SetAmount(amount uint64) *Transfer {
+	inst.Amount = &amount
+	return inst
+}
+
+// SetSourceAccount sets the "source" account.
+// The source account.
+func (inst *Transfer) SetSourceAccount(source ag_solanago.PublicKey) *Transfer {
+	inst.Accounts[0] = ag_solanago.Meta(source).WRITE()
+	return inst
+}
+
+// GetSourceAccount gets the "source" account.
+// The source account.
+func (inst *Transfer) GetSourceAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetDestinationAccount sets the "destination" account.
+// The destination account.
+func (inst *Transfer) SetDestinationAccount(destination ag_solanago.PublicKey) *Transfer {
+	inst.Accounts[1] = ag_solanago.Meta(destination).WRITE()
+	return inst
+}
+
+// GetDestinationAccount gets the "destination" account.
+// The destination account.
+func (inst *Transfer) GetDestinationAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetOwnerAccount sets the "owner" account.
+// The source account owner/delegate.
+func (inst *Transfer) SetOwnerAccount(owner ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *Transfer {
+	inst.Accounts[2] = ag_solanago.Meta(owner)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[2].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetOwnerAccount gets the "owner" account.
+// The source account owner/delegate.
+func (inst *Transfer) GetOwnerAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+func (inst Transfer) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_Transfer),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst Transfer) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *Transfer) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Amount == nil {
+			return errors.New("Amount parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return fmt.Errorf("accounts.Source is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return fmt.Errorf("accounts.Destination is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return fmt.Errorf("accounts.Owner is not set")
+		}
+		if !inst.Accounts[2].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *Transfer) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("Transfer")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("Amount", *inst.Amount))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("     source", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("destination", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("      owner", inst.Accounts[2]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj Transfer) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Amount` param:
+	err = encoder.Encode(obj.Amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *Transfer) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Amount`:
+	err = decoder.Decode(&obj.Amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewTransferInstruction declares a new Transfer instruction with the provided parameters and accounts.
+func NewTransferInstruction(
+	// Parameters:
+	amount uint64,
+	// Accounts:
+	source ag_solanago.PublicKey,
+	destination ag_solanago.PublicKey,
+	owner ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey) *Transfer {
+	return NewTransferInstructionBuilder().
+		SetAmount(amount).
+		SetSourceAccount(source).
+		SetDestinationAccount(destination).
+		SetOwnerAccount(owner, multisigSigners...)
+}

--- a/programs/token2022/TransferChecked.go
+++ b/programs/token2022/TransferChecked.go
@@ -1,0 +1,284 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Transfers tokens from one account to another either directly or via a
+// delegate.  If this account is associated with the native mint then equal
+// amounts of SOL and Tokens will be transferred to the destination
+// account.
+//
+// This instruction differs from Transfer in that the token mint and
+// decimals value is checked by the caller.  This may be useful when
+// creating transactions offline or within a hardware wallet.
+type TransferChecked struct {
+	// The amount of tokens to transfer.
+	Amount *uint64
+
+	// Expected number of base 10 digits to the right of the decimal place.
+	Decimals *uint8
+
+	// [0] = [WRITE] source
+	// ··········· The source account.
+	//
+	// [1] = [] mint
+	// ··········· The token mint.
+	//
+	// [2] = [WRITE] destination
+	// ··········· The destination account.
+	//
+	// [3] = [] owner
+	// ··········· The source account's owner/delegate.
+	//
+	// [4...] = [SIGNER] signers
+	// ··········· M signer accounts.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *TransferChecked) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	obj.Accounts, obj.Signers = ag_solanago.AccountMetaSlice(accounts).SplitFrom(4)
+	return nil
+}
+
+func (slice TransferChecked) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Accounts...)
+	accounts = append(accounts, slice.Signers...)
+	return
+}
+
+// NewTransferCheckedInstructionBuilder creates a new `TransferChecked` instruction builder.
+func NewTransferCheckedInstructionBuilder() *TransferChecked {
+	nd := &TransferChecked{
+		Accounts: make(ag_solanago.AccountMetaSlice, 4),
+		Signers:  make(ag_solanago.AccountMetaSlice, 0),
+	}
+	return nd
+}
+
+// SetAmount sets the "amount" parameter.
+// The amount of tokens to transfer.
+func (inst *TransferChecked) SetAmount(amount uint64) *TransferChecked {
+	inst.Amount = &amount
+	return inst
+}
+
+// SetDecimals sets the "decimals" parameter.
+// Expected number of base 10 digits to the right of the decimal place.
+func (inst *TransferChecked) SetDecimals(decimals uint8) *TransferChecked {
+	inst.Decimals = &decimals
+	return inst
+}
+
+// SetSourceAccount sets the "source" account.
+// The source account.
+func (inst *TransferChecked) SetSourceAccount(source ag_solanago.PublicKey) *TransferChecked {
+	inst.Accounts[0] = ag_solanago.Meta(source).WRITE()
+	return inst
+}
+
+// GetSourceAccount gets the "source" account.
+// The source account.
+func (inst *TransferChecked) GetSourceAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+// SetMintAccount sets the "mint" account.
+// The token mint.
+func (inst *TransferChecked) SetMintAccount(mint ag_solanago.PublicKey) *TransferChecked {
+	inst.Accounts[1] = ag_solanago.Meta(mint)
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The token mint.
+func (inst *TransferChecked) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[1]
+}
+
+// SetDestinationAccount sets the "destination" account.
+// The destination account.
+func (inst *TransferChecked) SetDestinationAccount(destination ag_solanago.PublicKey) *TransferChecked {
+	inst.Accounts[2] = ag_solanago.Meta(destination).WRITE()
+	return inst
+}
+
+// GetDestinationAccount gets the "destination" account.
+// The destination account.
+func (inst *TransferChecked) GetDestinationAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[2]
+}
+
+// SetOwnerAccount sets the "owner" account.
+// The source account's owner/delegate.
+func (inst *TransferChecked) SetOwnerAccount(owner ag_solanago.PublicKey, multisigSigners ...ag_solanago.PublicKey) *TransferChecked {
+	inst.Accounts[3] = ag_solanago.Meta(owner)
+	if len(multisigSigners) == 0 {
+		inst.Accounts[3].SIGNER()
+	}
+	for _, signer := range multisigSigners {
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+	}
+	return inst
+}
+
+// GetOwnerAccount gets the "owner" account.
+// The source account's owner/delegate.
+func (inst *TransferChecked) GetOwnerAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[3]
+}
+
+func (inst TransferChecked) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_TransferChecked),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst TransferChecked) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *TransferChecked) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Amount == nil {
+			return errors.New("Amount parameter is not set")
+		}
+		if inst.Decimals == nil {
+			return errors.New("Decimals parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Source is not set")
+		}
+		if inst.Accounts[1] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+		if inst.Accounts[2] == nil {
+			return errors.New("accounts.Destination is not set")
+		}
+		if inst.Accounts[3] == nil {
+			return errors.New("accounts.Owner is not set")
+		}
+		if !inst.Accounts[3].IsSigner && len(inst.Signers) == 0 {
+			return fmt.Errorf("accounts.Signers is not set")
+		}
+		if len(inst.Signers) > MAX_SIGNERS {
+			return fmt.Errorf("too many signers; got %v, but max is 11", len(inst.Signers))
+		}
+	}
+	return nil
+}
+
+func (inst *TransferChecked) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("TransferChecked")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("  Amount", *inst.Amount))
+						paramsBranch.Child(ag_format.Param("Decimals", *inst.Decimals))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("     source", inst.Accounts[0]))
+						accountsBranch.Child(ag_format.Meta("       mint", inst.Accounts[1]))
+						accountsBranch.Child(ag_format.Meta("destination", inst.Accounts[2]))
+						accountsBranch.Child(ag_format.Meta("      owner", inst.Accounts[3]))
+
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for i, v := range inst.Signers {
+							if len(inst.Signers) > 9 && i < 10 {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf(" [%v]", i), v))
+							} else {
+								signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), v))
+							}
+						}
+					})
+				})
+		})
+}
+
+func (obj TransferChecked) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Amount` param:
+	err = encoder.Encode(obj.Amount)
+	if err != nil {
+		return err
+	}
+	// Serialize `Decimals` param:
+	err = encoder.Encode(obj.Decimals)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (obj *TransferChecked) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Amount`:
+	err = decoder.Decode(&obj.Amount)
+	if err != nil {
+		return err
+	}
+	// Deserialize `Decimals`:
+	err = decoder.Decode(&obj.Decimals)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewTransferCheckedInstruction declares a new TransferChecked instruction with the provided parameters and accounts.
+func NewTransferCheckedInstruction(
+	// Parameters:
+	amount uint64,
+	decimals uint8,
+	// Accounts:
+	source ag_solanago.PublicKey,
+	mint ag_solanago.PublicKey,
+	destination ag_solanago.PublicKey,
+	owner ag_solanago.PublicKey,
+	multisigSigners []ag_solanago.PublicKey,
+) *TransferChecked {
+	return NewTransferCheckedInstructionBuilder().
+		SetAmount(amount).
+		SetDecimals(decimals).
+		SetSourceAccount(source).
+		SetMintAccount(mint).
+		SetDestinationAccount(destination).
+		SetOwnerAccount(owner, multisigSigners...)
+}

--- a/programs/token2022/TransferChecked_test.go
+++ b/programs/token2022/TransferChecked_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_TransferChecked(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("TransferChecked"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(TransferChecked)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(TransferChecked)
+				err = decodeT(got, buf.Bytes())
+				params.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/Transfer_test.go
+++ b/programs/token2022/Transfer_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode_Transfer(t *testing.T) {
+	fu := ag_gofuzz.New().NilChance(0)
+	for i := 0; i < 1; i++ {
+		t.Run("Transfer"+strconv.Itoa(i), func(t *testing.T) {
+			{
+				params := new(Transfer)
+				fu.Fuzz(params)
+				params.Accounts = nil
+				params.Signers = nil
+				buf := new(bytes.Buffer)
+				err := encodeT(*params, buf)
+				ag_require.NoError(t, err)
+				//
+				got := new(Transfer)
+				err = decodeT(got, buf.Bytes())
+				got.Accounts = nil
+				params.Signers = nil
+				ag_require.NoError(t, err)
+				ag_require.Equal(t, params, got)
+			}
+		})
+	}
+}

--- a/programs/token2022/accounts.go
+++ b/programs/token2022/accounts.go
@@ -1,0 +1,397 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"encoding/binary"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go"
+)
+
+type Mint struct {
+	// Optional authority used to mint new tokens. The mint authority may only be provided during
+	// mint creation. If no mint authority is present then the mint has a fixed supply and no
+	// further tokens may be minted.
+	MintAuthority *solana.PublicKey `bin:"optional"`
+
+	// Total supply of tokens.
+	Supply uint64
+
+	// Number of base 10 digits to the right of the decimal place.
+	Decimals uint8
+
+	// Is `true` if this structure has been initialized
+	IsInitialized bool
+
+	// Optional authority to freeze token accounts.
+	FreezeAuthority *solana.PublicKey `bin:"optional"`
+}
+
+func (mint *Mint) UnmarshalWithDecoder(dec *bin.Decoder) (err error) {
+	{
+		v, err := dec.ReadUint32(binary.LittleEndian)
+		if err != nil {
+			return err
+		}
+		if v == 1 {
+			v, err := dec.ReadNBytes(32)
+			if err != nil {
+				return err
+			}
+			mint.MintAuthority = solana.PublicKeyFromBytes(v).ToPointer()
+		} else {
+			// discard:
+			_, err := dec.ReadNBytes(32)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	{
+		v, err := dec.ReadUint64(binary.LittleEndian)
+		if err != nil {
+			return err
+		}
+		mint.Supply = v
+	}
+	{
+		v, err := dec.ReadUint8()
+		if err != nil {
+			return err
+		}
+		mint.Decimals = v
+	}
+	{
+		v, err := dec.ReadBool()
+		if err != nil {
+			return err
+		}
+		mint.IsInitialized = v
+	}
+	{
+		v, err := dec.ReadUint32(binary.LittleEndian)
+		if err != nil {
+			return err
+		}
+		if v == 1 {
+			v, err := dec.ReadNBytes(32)
+			if err != nil {
+				return err
+			}
+			mint.FreezeAuthority = solana.PublicKeyFromBytes(v).ToPointer()
+		} else {
+			// discard:
+			_, err := dec.ReadNBytes(32)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (mint Mint) MarshalWithEncoder(encoder *bin.Encoder) (err error) {
+	{
+		if mint.MintAuthority == nil {
+			err = encoder.WriteUint32(0, binary.LittleEndian)
+			if err != nil {
+				return err
+			}
+			empty := solana.PublicKey{}
+			err = encoder.WriteBytes(empty[:], false)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = encoder.WriteUint32(1, binary.LittleEndian)
+			if err != nil {
+				return err
+			}
+			err = encoder.WriteBytes(mint.MintAuthority[:], false)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	err = encoder.WriteUint64(mint.Supply, binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	err = encoder.WriteUint8(mint.Decimals)
+	if err != nil {
+		return err
+	}
+	err = encoder.WriteBool(mint.IsInitialized)
+	if err != nil {
+		return err
+	}
+	{
+		if mint.FreezeAuthority == nil {
+			err = encoder.WriteUint32(0, binary.LittleEndian)
+			if err != nil {
+				return err
+			}
+			empty := solana.PublicKey{}
+			err = encoder.WriteBytes(empty[:], false)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = encoder.WriteUint32(1, binary.LittleEndian)
+			if err != nil {
+				return err
+			}
+			err = encoder.WriteBytes(mint.FreezeAuthority[:], false)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+type Account struct {
+	// The mint associated with this account
+	Mint solana.PublicKey
+
+	// The owner of this account.
+	Owner solana.PublicKey
+
+	// The amount of tokens this account holds.
+	Amount uint64
+
+	// If `delegate` is `Some` then `delegated_amount` represents
+	// the amount authorized by the delegate
+	Delegate *solana.PublicKey `bin:"optional"`
+
+	// The account's state
+	State AccountState
+
+	// If is_some, this is a native token, and the value logs the rent-exempt reserve. An Account
+	// is required to be rent-exempt, so the value is used by the Processor to ensure that wrapped
+	// SOL accounts do not drop below this threshold.
+	IsNative *uint64 `bin:"optional"`
+
+	// The amount delegated
+	DelegatedAmount uint64
+
+	// Optional authority to close the account.
+	CloseAuthority *solana.PublicKey `bin:"optional"`
+}
+
+func (mint *Account) UnmarshalWithDecoder(dec *bin.Decoder) (err error) {
+	{
+		v, err := dec.ReadNBytes(32)
+		if err != nil {
+			return err
+		}
+		mint.Mint = solana.PublicKeyFromBytes(v)
+	}
+	{
+		v, err := dec.ReadNBytes(32)
+		if err != nil {
+			return err
+		}
+		mint.Owner = solana.PublicKeyFromBytes(v)
+	}
+	{
+		v, err := dec.ReadUint64(binary.LittleEndian)
+		if err != nil {
+			return err
+		}
+		mint.Amount = v
+	}
+	{
+		v, err := dec.ReadUint32(binary.LittleEndian)
+		if err != nil {
+			return err
+		}
+		if v == 1 {
+			v, err := dec.ReadNBytes(32)
+			if err != nil {
+				return err
+			}
+			mint.Delegate = solana.PublicKeyFromBytes(v).ToPointer()
+		} else {
+			// discard:
+			_, err := dec.ReadNBytes(32)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	{
+		v, err := dec.ReadUint8()
+		if err != nil {
+			return err
+		}
+		mint.State = AccountState(v)
+	}
+	{
+		v, err := dec.ReadUint32(binary.LittleEndian)
+		if err != nil {
+			return err
+		}
+		if v == 1 {
+			v, err := dec.ReadUint64(bin.LE)
+			if err != nil {
+				return err
+			}
+			mint.IsNative = &v
+		} else {
+			// discard:
+			_, err := dec.ReadUint64(bin.LE)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	{
+		v, err := dec.ReadUint64(binary.LittleEndian)
+		if err != nil {
+			return err
+		}
+		mint.DelegatedAmount = v
+	}
+	{
+		v, err := dec.ReadUint32(binary.LittleEndian)
+		if err != nil {
+			return err
+		}
+		if v == 1 {
+			v, err := dec.ReadNBytes(32)
+			if err != nil {
+				return err
+			}
+			mint.CloseAuthority = solana.PublicKeyFromBytes(v).ToPointer()
+		} else {
+			// discard:
+			_, err := dec.ReadNBytes(32)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (mint Account) MarshalWithEncoder(encoder *bin.Encoder) (err error) {
+	{
+		err = encoder.WriteBytes(mint.Mint[:], false)
+		if err != nil {
+			return err
+		}
+	}
+	{
+		err = encoder.WriteBytes(mint.Owner[:], false)
+		if err != nil {
+			return err
+		}
+	}
+	{
+		err = encoder.WriteUint64(mint.Amount, bin.LE)
+		if err != nil {
+			return err
+		}
+	}
+	{
+		if mint.Delegate == nil {
+			err = encoder.WriteUint32(0, binary.LittleEndian)
+			if err != nil {
+				return err
+			}
+			empty := solana.PublicKey{}
+			err = encoder.WriteBytes(empty[:], false)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = encoder.WriteUint32(1, binary.LittleEndian)
+			if err != nil {
+				return err
+			}
+			err = encoder.WriteBytes(mint.Delegate[:], false)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	err = encoder.WriteUint8(uint8(mint.State))
+	if err != nil {
+		return err
+	}
+	{
+		if mint.IsNative == nil {
+			err = encoder.WriteUint32(0, binary.LittleEndian)
+			if err != nil {
+				return err
+			}
+			err = encoder.WriteUint64(0, bin.LE)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = encoder.WriteUint32(1, binary.LittleEndian)
+			if err != nil {
+				return err
+			}
+			err = encoder.WriteUint64(*mint.IsNative, bin.LE)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	{
+		err = encoder.WriteUint64(mint.DelegatedAmount, bin.LE)
+		if err != nil {
+			return err
+		}
+	}
+	{
+		if mint.CloseAuthority == nil {
+			err = encoder.WriteUint32(0, binary.LittleEndian)
+			if err != nil {
+				return err
+			}
+			empty := solana.PublicKey{}
+			err = encoder.WriteBytes(empty[:], false)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = encoder.WriteUint32(1, binary.LittleEndian)
+			if err != nil {
+				return err
+			}
+			err = encoder.WriteBytes(mint.CloseAuthority[:], false)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+type Multisig struct {
+	// Number of signers required
+	M uint8
+	// Number of valid signers
+	N uint8
+	// Is `true` if this structure has been initialized
+	IsInitialized bool
+	// Signer public keys
+	Signers [MAX_SIGNERS]solana.PublicKey
+}

--- a/programs/token2022/accounts_test.go
+++ b/programs/token2022/accounts_test.go
@@ -1,0 +1,96 @@
+package token2022
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMint(t *testing.T) {
+	accountBytes := []byte{
+		1, 0, 0, 0,
+		5, 234, 156, 241, 108, 228, 17, 152, 241, 164, 153, 55, 200, 140, 55, 10, 148, 212, 175, 255, 137, 181, 186, 203, 142, 244, 94, 99, 36, 187, 120, 247,
+		9, 169, 49, 235, 241, 182, 6, 0,
+		6,
+		1,
+		1, 0, 0, 0,
+		5, 234, 156, 241, 108, 228, 17, 152, 241, 164, 153, 55, 200, 140, 55, 10, 148, 212, 175, 255, 137, 181, 186, 203, 142, 244, 94, 99, 36, 187, 120, 247,
+	}
+	{
+		dec := bin.NewBinDecoder(accountBytes)
+		mint := Mint{}
+
+		err := dec.Decode(&mint)
+		require.NoError(t, err, spew.Sdump(mint))
+
+		require.Equal(t,
+			&Mint{
+				MintAuthority:   solana.MustPublicKeyFromBase58("Q6XprfkF8RQQKoQVG33xT88H7wi8Uk1B1CC7YAs69Gi").ToPointer(),
+				Supply:          1890000009537801,
+				Decimals:        6,
+				IsInitialized:   true,
+				FreezeAuthority: solana.MustPublicKeyFromBase58("Q6XprfkF8RQQKoQVG33xT88H7wi8Uk1B1CC7YAs69Gi").ToPointer(),
+			},
+			&mint,
+		)
+
+		{
+			buf := new(bytes.Buffer)
+			err := bin.NewBinEncoder(buf).Encode(mint)
+			require.NoError(t, err)
+			require.Equal(t, accountBytes, buf.Bytes(), bin.FormatByteSlice(buf.Bytes()))
+		}
+	}
+}
+
+func TestAccount(t *testing.T) {
+	accountBytes := []byte{
+		6, 155, 136, 87, 254, 171, 129, 132, 251, 104, 127, 99, 70, 24, 192, 53, 218, 196, 57, 220, 26, 235, 59, 85, 152, 160, 240, 0, 0, 0, 0, 1,
+		93, 100, 62, 133, 31, 102, 235, 161, 170, 152, 161, 7, 39, 223, 9, 180, 1, 224, 134, 204, 54, 241, 9, 195, 240, 147, 219, 146, 35, 92, 26, 224,
+		42, 34, 176, 1, 0, 0, 0, 0,
+
+		0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+		1,
+		1, 0, 0, 0,
+		240, 29, 31, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+
+		0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	}
+	{
+		dec := bin.NewBinDecoder(accountBytes)
+		account := Account{}
+
+		err := dec.Decode(&account)
+		require.NoError(t, err, spew.Sdump(account))
+
+		balance := uint64(2039280)
+		require.Equal(t,
+			&Account{
+				Mint:            solana.MustPublicKeyFromBase58("So11111111111111111111111111111111111111112"),
+				Owner:           solana.MustPublicKeyFromBase58("7HZaCWazgTuuFuajxaaxGYbGnyVKwxvsJKue1W4Nvyro"),
+				Amount:          (uint64)(28320298),
+				Delegate:        (*solana.PublicKey)(nil),
+				State:           (AccountState)(1),
+				IsNative:        (*uint64)(&balance),
+				DelegatedAmount: (uint64)(0),
+				CloseAuthority:  (*solana.PublicKey)(nil),
+			},
+			&account,
+		)
+
+		{
+			buf := bin.NewWriteByWrite("")
+			err := bin.NewBinEncoder(buf).Encode(account)
+			require.NoError(t, err)
+			require.Equal(t, accountBytes, buf.Bytes(), bin.FormatByteSlice(buf.Bytes()))
+		}
+	}
+}

--- a/programs/token2022/error.go
+++ b/programs/token2022/error.go
@@ -1,0 +1,235 @@
+package token2022
+
+type Error interface {
+	error
+	xx_isTokenError()
+}
+
+func CustomErrorResolver(code int) (error, bool) {
+	switch code {
+	case 0:
+		return Error_NotRentExempt{}, true
+	case 1:
+		return Error_InsufficientFunds{}, true
+	case 2:
+		return Error_InvalidMint{}, true
+	case 3:
+		return Error_MintMismatch{}, true
+	case 4:
+		return Error_OwnerMismatch{}, true
+	case 5:
+		return Error_FixedSupply{}, true
+	case 6:
+		return Error_AlreadyInUse{}, true
+	case 7:
+		return Error_InvalidNumberOfProvidedSigners{}, true
+	case 8:
+		return Error_InvalidNumberOfRequiredSigners{}, true
+	case 9:
+		return Error_UninitializedState{}, true
+	case 10:
+		return Error_NativeNotSupported{}, true
+	case 11:
+		return Error_NonNativeHasBalance{}, true
+	case 12:
+		return Error_InvalidInstruction{}, true
+	case 13:
+		return Error_InvalidState{}, true
+	case 14:
+		return Error_Overflow{}, true
+	case 15:
+		return Error_AuthorityTypeNotSupported{}, true
+	case 16:
+		return Error_MintCannotFreeze{}, true
+	case 17:
+		return Error_AccountFrozen{}, true
+	case 18:
+		return Error_MintDecimalsMismatch{}, true
+	case 19:
+		return Error_NonNativeNotSupported{}, true
+	default:
+		return nil, false
+	}
+}
+
+// Defined [here](https://github.com/solana-labs/solana-program-library/blob/9b3b5d8841484f19f927b1f49aa37bbd4da2a1ca/token/program/src/error.rs#L13).
+
+// Lamport balance below rent-exempt threshold.
+type Error_NotRentExempt struct{}
+
+func (Error_NotRentExempt) Error() string {
+	return "Lamport balance below rent-exempt threshold"
+}
+
+func (Error_NotRentExempt) xx_isTokenError() {}
+
+// Insufficient funds for the operation requested.
+type Error_InsufficientFunds struct{}
+
+func (Error_InsufficientFunds) Error() string {
+	return "Insufficient funds"
+}
+
+func (Error_InsufficientFunds) xx_isTokenError() {}
+
+// Invalid Mint.
+type Error_InvalidMint struct{}
+
+func (Error_InvalidMint) Error() string {
+	return "Invalid Mint"
+}
+
+func (Error_InvalidMint) xx_isTokenError() {}
+
+// Account not associated with this Mint.
+type Error_MintMismatch struct{}
+
+func (Error_MintMismatch) Error() string {
+	return "Account not associated with this Mint"
+}
+
+func (Error_MintMismatch) xx_isTokenError() {}
+
+// Owner does not match.
+type Error_OwnerMismatch struct{}
+
+func (Error_OwnerMismatch) Error() string {
+	return "Owner does not match"
+}
+
+func (Error_OwnerMismatch) xx_isTokenError() {}
+
+// This token's supply is fixed and new tokens cannot be minted.
+type Error_FixedSupply struct{}
+
+func (Error_FixedSupply) Error() string {
+	return "Fixed supply"
+}
+
+func (Error_FixedSupply) xx_isTokenError() {}
+
+// The account cannot be initialized because it is already being used.
+type Error_AlreadyInUse struct{}
+
+func (Error_AlreadyInUse) Error() string {
+	return "Already in use"
+}
+
+func (Error_AlreadyInUse) xx_isTokenError() {}
+
+// Invalid number of provided signers.
+type Error_InvalidNumberOfProvidedSigners struct{}
+
+func (Error_InvalidNumberOfProvidedSigners) Error() string {
+	return "Invalid number of provided signers"
+}
+
+func (Error_InvalidNumberOfProvidedSigners) xx_isTokenError() {}
+
+// Invalid number of required signers.
+type Error_InvalidNumberOfRequiredSigners struct{}
+
+func (Error_InvalidNumberOfRequiredSigners) Error() string {
+	return "Invalid number of required signers"
+}
+
+func (Error_InvalidNumberOfRequiredSigners) xx_isTokenError() {}
+
+// State is uninitialized.
+type Error_UninitializedState struct{}
+
+func (Error_UninitializedState) Error() string {
+	return "State is uninitialized"
+}
+
+func (Error_UninitializedState) xx_isTokenError() {}
+
+// Instruction does not support native tokens.
+type Error_NativeNotSupported struct{}
+
+func (Error_NativeNotSupported) Error() string {
+	return "Instruction does not support native tokens"
+}
+
+func (Error_NativeNotSupported) xx_isTokenError() {}
+
+// Non-native account can only be closed if its balance is zero.
+type Error_NonNativeHasBalance struct{}
+
+func (Error_NonNativeHasBalance) Error() string {
+	return "Non-native account can only be closed if its balance is zero"
+}
+
+func (Error_NonNativeHasBalance) xx_isTokenError() {}
+
+// Invalid instruction.
+type Error_InvalidInstruction struct{}
+
+func (Error_InvalidInstruction) Error() string {
+	return "Invalid instruction"
+}
+
+func (Error_InvalidInstruction) xx_isTokenError() {}
+
+// State is invalid for requested operation.
+type Error_InvalidState struct{}
+
+func (Error_InvalidState) Error() string {
+	return "State is invalid for requested operation"
+}
+
+func (Error_InvalidState) xx_isTokenError() {}
+
+// Operation overflowed.
+type Error_Overflow struct{}
+
+func (Error_Overflow) Error() string {
+	return "Operation overflowed"
+}
+
+func (Error_Overflow) xx_isTokenError() {}
+
+// Account does not support specified authority type.
+type Error_AuthorityTypeNotSupported struct{}
+
+func (Error_AuthorityTypeNotSupported) Error() string {
+	return "Account does not support specified authority type"
+}
+
+func (Error_AuthorityTypeNotSupported) xx_isTokenError() {}
+
+// This token mint cannot freeze accounts.
+type Error_MintCannotFreeze struct{}
+
+func (Error_MintCannotFreeze) Error() string {
+	return "This token mint cannot freeze accounts"
+}
+
+func (Error_MintCannotFreeze) xx_isTokenError() {}
+
+// Account is frozen; all account operations will fail.
+type Error_AccountFrozen struct{}
+
+func (Error_AccountFrozen) Error() string {
+	return "Account is frozen"
+}
+
+func (Error_AccountFrozen) xx_isTokenError() {}
+
+// Mint decimals mismatch between the client and mint.
+type Error_MintDecimalsMismatch struct{}
+
+func (Error_MintDecimalsMismatch) Error() string {
+	return "The provided decimals value different from the Mint decimals"
+}
+
+func (Error_MintDecimalsMismatch) xx_isTokenError() {}
+
+// Instruction does not support non-native tokens.
+type Error_NonNativeNotSupported struct{}
+
+func (Error_NonNativeNotSupported) Error() string {
+	return "Instruction does not support non-native tokens"
+}
+
+func (Error_NonNativeNotSupported) xx_isTokenError() {}

--- a/programs/token2022/error_test.go
+++ b/programs/token2022/error_test.go
@@ -1,0 +1,44 @@
+package token2022
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/test-go/testify/assert"
+	"github.com/test-go/testify/require"
+)
+
+func TestParseError(t *testing.T) {
+	t.Parallel()
+	var (
+		err error
+		ok  bool
+	)
+
+	tx, err := solana.NewTransaction([]solana.Instruction{
+		NewTransferInstruction(
+			0,
+			solana.PublicKey{},
+			solana.PublicKey{},
+			solana.PublicKey{},
+			nil,
+		).Build(),
+	}, solana.Hash{})
+	require.NoError(t, err)
+	err, ok = solana.ParseTransactionError(tx, map[string]interface{}{
+		"InstructionError": []interface{}{
+			float64(0),
+			map[string]interface{}{
+				"Custom": float64(1),
+			},
+		},
+	})
+	require.True(t, ok)
+	assert.Equal(t, &solana.TransactionError_InstructionError{
+		Index: 0,
+		Cause: &solana.InstructionError_Custom{
+			Code:  1,
+			Cause: Error_InsufficientFunds{},
+		},
+	}, err.(interface{ Unwrap() error }).Unwrap())
+}

--- a/programs/token2022/instruction_decoder.go
+++ b/programs/token2022/instruction_decoder.go
@@ -1,0 +1,37 @@
+package token2022
+
+import (
+	"github.com/gagliardetto/solana-go"
+)
+
+var (
+	DecodeApprove             = decode[*Approve]()
+	DecodeApproveChecked      = decode[*ApproveChecked]()
+	DecodeBurn                = decode[*Burn]()
+	DecodeBurnChecked         = decode[*BurnChecked]()
+	DecodeCloseAccount        = decode[*CloseAccount]()
+	DecodeFreezeAccount       = decode[*FreezeAccount]()
+	DecodeInitializeAccount   = decode[*InitializeAccount]()
+	DecodeInitializeAccount2  = decode[*InitializeAccount2]()
+	DecodeInitializeAccount3  = decode[*InitializeAccount3]()
+	DecodeInitializeMint      = decode[*InitializeMint]()
+	DecodeInitializeMint2     = decode[*InitializeMint2]()
+	DecodeInitializeMultisig  = decode[*InitializeMultisig]()
+	DecodeInitializeMultisig2 = decode[*InitializeMultisig2]()
+	DecodeMintTo              = decode[*MintTo]()
+	DecodeMintToChecked       = decode[*MintToChecked]()
+	DecodeRevoke              = decode[*Revoke]()
+	DecodeSetAuthority        = decode[*SetAuthority]()
+	DecodeSyncNative          = decode[*SyncNative]()
+	DecodeThawAccount         = decode[*ThawAccount]()
+	DecodeTransfer            = decode[*Transfer]()
+	DecodeTransferChecked     = decode[*TransferChecked]()
+)
+
+func decode[T any]() func(*solana.Message, int) (T, error) {
+	return solana.DecodeInstructionType[*Instruction, T](
+		ProgramID,
+		InstructionImplDef,
+		DecodeInstruction,
+	)
+}

--- a/programs/token2022/instructions.go
+++ b/programs/token2022/instructions.go
@@ -1,0 +1,362 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A Token program on the Solana blockchain.
+// This program defines a common implementation for Fungible and Non Fungible tokens.
+
+package token2022
+
+import (
+	"bytes"
+	"fmt"
+
+	ag_spew "github.com/davecgh/go-spew/spew"
+	ag_binary "github.com/gagliardetto/binary"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_text "github.com/gagliardetto/solana-go/text"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// Maximum number of multisignature signers (max N)
+const MAX_SIGNERS = 11
+
+var ProgramID ag_solanago.PublicKey = ag_solanago.Token2022ProgramID
+
+func SetProgramID(pubkey ag_solanago.PublicKey) {
+	ProgramID = pubkey
+	ag_solanago.RegisterInstructionDecoder(ProgramID, registryDecodeInstruction)
+}
+
+const ProgramName = "Token"
+
+func init() {
+	if !ProgramID.IsZero() {
+		ag_solanago.RegisterInstructionDecoder(ProgramID, registryDecodeInstruction)
+		ag_solanago.RegisterCustomInstructionErrorResolver(ProgramID, CustomErrorResolver)
+	}
+}
+
+const (
+	// Initializes a new mint and optionally deposits all the newly minted
+	// tokens in an account.
+	//
+	// The `InitializeMint` instruction requires no signers and MUST be
+	// included within the same Transaction as the system program's
+	// `CreateAccount` instruction that creates the account being initialized.
+	// Otherwise another party can acquire ownership of the uninitialized
+	// account.
+	Instruction_InitializeMint uint8 = iota
+
+	// Initializes a new account to hold tokens.  If this account is associated
+	// with the native mint then the token balance of the initialized account
+	// will be equal to the amount of SOL in the account. If this account is
+	// associated with another mint, that mint must be initialized before this
+	// command can succeed.
+	//
+	// The `InitializeAccount` instruction requires no signers and MUST be
+	// included within the same Transaction as the system program's
+	// `CreateAccount` instruction that creates the account being initialized.
+	// Otherwise another party can acquire ownership of the uninitialized
+	// account.
+	Instruction_InitializeAccount
+
+	// Initializes a multisignature account with N provided signers.
+	//
+	// Multisignature accounts can used in place of any single owner/delegate
+	// accounts in any token instruction that require an owner/delegate to be
+	// present.  The variant field represents the number of signers (M)
+	// required to validate this multisignature account.
+	//
+	// The `InitializeMultisig` instruction requires no signers and MUST be
+	// included within the same Transaction as the system program's
+	// `CreateAccount` instruction that creates the account being initialized.
+	// Otherwise another party can acquire ownership of the uninitialized
+	// account.
+	Instruction_InitializeMultisig
+
+	// Transfers tokens from one account to another either directly or via a
+	// delegate.  If this account is associated with the native mint then equal
+	// amounts of SOL and Tokens will be transferred to the destination
+	// account.
+	Instruction_Transfer
+
+	// Approves a delegate.  A delegate is given the authority over tokens on
+	// behalf of the source account's owner.
+	Instruction_Approve
+
+	// Revokes the delegate's authority.
+	Instruction_Revoke
+
+	// Sets a new authority of a mint or account.
+	Instruction_SetAuthority
+
+	// Mints new tokens to an account.  The native mint does not support
+	// minting.
+	Instruction_MintTo
+
+	// Burns tokens by removing them from an account.  `Burn` does not support
+	// accounts associated with the native mint, use `CloseAccount` instead.
+	Instruction_Burn
+
+	// Close an account by transferring all its SOL to the destination account.
+	// Non-native accounts may only be closed if its token amount is zero.
+	Instruction_CloseAccount
+
+	// Freeze an Initialized account using the Mint's freeze_authority (if set).
+	Instruction_FreezeAccount
+
+	// Thaw a Frozen account using the Mint's freeze_authority (if set).
+	Instruction_ThawAccount
+
+	// Transfers tokens from one account to another either directly or via a
+	// delegate.  If this account is associated with the native mint then equal
+	// amounts of SOL and Tokens will be transferred to the destination
+	// account.
+	//
+	// This instruction differs from Transfer in that the token mint and
+	// decimals value is checked by the caller.  This may be useful when
+	// creating transactions offline or within a hardware wallet.
+	Instruction_TransferChecked
+
+	// Approves a delegate.  A delegate is given the authority over tokens on
+	// behalf of the source account's owner.
+	//
+	// This instruction differs from Approve in that the token mint and
+	// decimals value is checked by the caller.  This may be useful when
+	// creating transactions offline or within a hardware wallet.
+	Instruction_ApproveChecked
+
+	// Mints new tokens to an account.  The native mint does not support minting.
+	//
+	// This instruction differs from MintTo in that the decimals value is
+	// checked by the caller.  This may be useful when creating transactions
+	// offline or within a hardware wallet.
+	Instruction_MintToChecked
+
+	// Burns tokens by removing them from an account.  `BurnChecked` does not
+	// support accounts associated with the native mint, use `CloseAccount`
+	// instead.
+	//
+	// This instruction differs from Burn in that the decimals value is checked
+	// by the caller. This may be useful when creating transactions offline or
+	// within a hardware wallet.
+	Instruction_BurnChecked
+
+	// Like InitializeAccount, but the owner pubkey is passed via instruction data
+	// rather than the accounts list. This variant may be preferable when using
+	// Cross Program Invocation from an instruction that does not need the owner's
+	// `AccountInfo` otherwise.
+	Instruction_InitializeAccount2
+
+	// Given a wrapped / native token account (a token account containing SOL)
+	// updates its amount field based on the account's underlying `lamports`.
+	// This is useful if a non-wrapped SOL account uses `system_instruction::transfer`
+	// to move lamports to a wrapped token account, and needs to have its token
+	// `amount` field updated.
+	Instruction_SyncNative
+
+	// Like InitializeAccount2, but does not require the Rent sysvar to be provided.
+	Instruction_InitializeAccount3
+
+	// Like InitializeMultisig, but does not require the Rent sysvar to be provided.
+	Instruction_InitializeMultisig2
+
+	// Like InitializeMint, but does not require the Rent sysvar to be provided.
+	Instruction_InitializeMint2
+)
+
+// InstructionIDToName returns the name of the instruction given its ID.
+func InstructionIDToName(id uint8) string {
+	switch id {
+	case Instruction_InitializeMint:
+		return "InitializeMint"
+	case Instruction_InitializeAccount:
+		return "InitializeAccount"
+	case Instruction_InitializeMultisig:
+		return "InitializeMultisig"
+	case Instruction_Transfer:
+		return "Transfer"
+	case Instruction_Approve:
+		return "Approve"
+	case Instruction_Revoke:
+		return "Revoke"
+	case Instruction_SetAuthority:
+		return "SetAuthority"
+	case Instruction_MintTo:
+		return "MintTo"
+	case Instruction_Burn:
+		return "Burn"
+	case Instruction_CloseAccount:
+		return "CloseAccount"
+	case Instruction_FreezeAccount:
+		return "FreezeAccount"
+	case Instruction_ThawAccount:
+		return "ThawAccount"
+	case Instruction_TransferChecked:
+		return "TransferChecked"
+	case Instruction_ApproveChecked:
+		return "ApproveChecked"
+	case Instruction_MintToChecked:
+		return "MintToChecked"
+	case Instruction_BurnChecked:
+		return "BurnChecked"
+	case Instruction_InitializeAccount2:
+		return "InitializeAccount2"
+	case Instruction_SyncNative:
+		return "SyncNative"
+	case Instruction_InitializeAccount3:
+		return "InitializeAccount3"
+	case Instruction_InitializeMultisig2:
+		return "InitializeMultisig2"
+	case Instruction_InitializeMint2:
+		return "InitializeMint2"
+	default:
+		return ""
+	}
+}
+
+type Instruction struct {
+	ag_binary.BaseVariant
+}
+
+func (inst *Instruction) EncodeToTree(parent ag_treeout.Branches) {
+	if enToTree, ok := inst.Impl.(ag_text.EncodableToTree); ok {
+		enToTree.EncodeToTree(parent)
+	} else {
+		parent.Child(ag_spew.Sdump(inst))
+	}
+}
+
+var InstructionImplDef = ag_binary.NewVariantDefinition(
+	ag_binary.Uint8TypeIDEncoding,
+	[]ag_binary.VariantType{
+		{
+			"InitializeMint", (*InitializeMint)(nil),
+		},
+		{
+			"InitializeAccount", (*InitializeAccount)(nil),
+		},
+		{
+			"InitializeMultisig", (*InitializeMultisig)(nil),
+		},
+		{
+			"Transfer", (*Transfer)(nil),
+		},
+		{
+			"Approve", (*Approve)(nil),
+		},
+		{
+			"Revoke", (*Revoke)(nil),
+		},
+		{
+			"SetAuthority", (*SetAuthority)(nil),
+		},
+		{
+			"MintTo", (*MintTo)(nil),
+		},
+		{
+			"Burn", (*Burn)(nil),
+		},
+		{
+			"CloseAccount", (*CloseAccount)(nil),
+		},
+		{
+			"FreezeAccount", (*FreezeAccount)(nil),
+		},
+		{
+			"ThawAccount", (*ThawAccount)(nil),
+		},
+		{
+			"TransferChecked", (*TransferChecked)(nil),
+		},
+		{
+			"ApproveChecked", (*ApproveChecked)(nil),
+		},
+		{
+			"MintToChecked", (*MintToChecked)(nil),
+		},
+		{
+			"BurnChecked", (*BurnChecked)(nil),
+		},
+		{
+			"InitializeAccount2", (*InitializeAccount2)(nil),
+		},
+		{
+			"SyncNative", (*SyncNative)(nil),
+		},
+		{
+			"InitializeAccount3", (*InitializeAccount3)(nil),
+		},
+		{
+			"InitializeMultisig2", (*InitializeMultisig2)(nil),
+		},
+		{
+			"InitializeMint2", (*InitializeMint2)(nil),
+		},
+	},
+)
+
+func (inst *Instruction) ProgramID() ag_solanago.PublicKey {
+	return ProgramID
+}
+
+func (inst *Instruction) Accounts() (out []*ag_solanago.AccountMeta) {
+	return inst.Impl.(ag_solanago.AccountsGettable).GetAccounts()
+}
+
+func (inst *Instruction) Data() ([]byte, error) {
+	buf := new(bytes.Buffer)
+	if err := ag_binary.NewBinEncoder(buf).Encode(inst); err != nil {
+		return nil, fmt.Errorf("unable to encode instruction: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func (inst *Instruction) TextEncode(encoder *ag_text.Encoder, option *ag_text.Option) error {
+	return encoder.Encode(inst.Impl, option)
+}
+
+func (inst *Instruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) error {
+	return inst.BaseVariant.UnmarshalBinaryVariant(decoder, InstructionImplDef)
+}
+
+func (inst Instruction) MarshalWithEncoder(encoder *ag_binary.Encoder) error {
+	err := encoder.WriteUint8(inst.TypeID.Uint8())
+	if err != nil {
+		return fmt.Errorf("unable to write variant type: %w", err)
+	}
+	return encoder.Encode(inst.Impl)
+}
+
+func registryDecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (interface{}, error) {
+	inst, err := DecodeInstruction(accounts, data)
+	if err != nil {
+		return nil, err
+	}
+	return inst, nil
+}
+
+func DecodeInstruction(accounts []*ag_solanago.AccountMeta, data []byte) (*Instruction, error) {
+	inst := new(Instruction)
+	if err := ag_binary.NewBinDecoder(data).Decode(inst); err != nil {
+		return nil, fmt.Errorf("unable to decode instruction: %w", err)
+	}
+	if v, ok := inst.Impl.(ag_solanago.AccountsSettable); ok {
+		err := v.SetAccounts(accounts)
+		if err != nil {
+			return nil, fmt.Errorf("unable to set accounts for instruction: %w", err)
+		}
+	}
+	return inst, nil
+}

--- a/programs/token2022/json.go
+++ b/programs/token2022/json.go
@@ -1,0 +1,21 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	jsoniter "github.com/json-iterator/go"
+)
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary

--- a/programs/token2022/rpc.go
+++ b/programs/token2022/rpc.go
@@ -1,0 +1,69 @@
+// Copyright 2021 github.com/gagliardetto
+// This file has been modified by github.com/gagliardetto
+//
+// Copyright 2020 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"context"
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go/rpc"
+)
+
+const MINT_SIZE = 82
+
+func (mint *Mint) Decode(data []byte) error {
+	mint = new(Mint)
+	dec := bin.NewBinDecoder(data)
+	if err := dec.Decode(&mint); err != nil {
+		return fmt.Errorf("unable to decode mint: %w", err)
+	}
+	return nil
+}
+
+func FetchMints(ctx context.Context, rpcCli *rpc.Client) (out []*Mint, err error) {
+	resp, err := rpcCli.GetProgramAccountsWithOpts(
+		ctx,
+		ProgramID,
+		&rpc.GetProgramAccountsOpts{
+			Filters: []rpc.RPCFilter{
+				{
+					DataSize: MINT_SIZE,
+				},
+			},
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("resp empty... program account not found")
+	}
+
+	for _, keyedAcct := range resp {
+		acct := keyedAcct.Account
+
+		m := new(Mint)
+		if err := m.Decode(acct.Data.GetBinary()); err != nil {
+			return nil, fmt.Errorf("unable to decode mint %q: %w", acct.Owner.String(), err)
+		}
+		out = append(out, m)
+
+	}
+	return
+}

--- a/programs/token2022/testing_utils.go
+++ b/programs/token2022/testing_utils.go
@@ -1,0 +1,32 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	"bytes"
+	"fmt"
+	ag_binary "github.com/gagliardetto/binary"
+)
+
+func encodeT(data interface{}, buf *bytes.Buffer) error {
+	if err := ag_binary.NewBinEncoder(buf).Encode(data); err != nil {
+		return fmt.Errorf("unable to encode instruction: %w", err)
+	}
+	return nil
+}
+
+func decodeT(dst interface{}, data []byte) error {
+	return ag_binary.NewBinDecoder(data).Decode(dst)
+}

--- a/programs/token2022/types.go
+++ b/programs/token2022/types.go
@@ -1,0 +1,50 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token2022
+
+import (
+	ag_binary "github.com/gagliardetto/binary"
+)
+
+type AuthorityType ag_binary.BorshEnum
+
+const (
+	// Authority to mint new tokens
+	AuthorityMintTokens AuthorityType = iota
+
+	// Authority to freeze any account associated with the Mint
+	AuthorityFreezeAccount
+
+	// Owner of a given token account
+	AuthorityAccountOwner
+
+	// Authority to close a token account
+	AuthorityCloseAccount
+)
+
+type AccountState ag_binary.BorshEnum
+
+const (
+	// Account is not yet initialized
+	Uninitialized AccountState = iota
+
+	// Account is initialized; the account owner and/or delegate may perform permitted operations
+	// on this account
+	Initialized
+
+	// Account has been frozen by the mint freeze authority. Neither the account owner nor
+	// the delegate are able to perform operations on this account.
+	Frozen
+)


### PR DESCRIPTION
This PR introduces the `token2022` package with the relevant instructions. This program is _currently_ identical to the `token` program and instructions, other than the programID. But _in theory_ we might add the additional token2022 instructions to it.