### PR TITLE
Assert Equivalent

### DIFF
--- a/account.go
+++ b/account.go
@@ -77,6 +77,19 @@ func (meta *AccountMeta) SIGNER() *AccountMeta {
 	return meta
 }
 
+func (a *AccountMeta) AssertEquivalent(b *AccountMeta) error {
+	if a == nil && b != nil {
+		return fmt.Errorf("expected 'nil', but got '%v'", b)
+	}
+	if a == nil && b == nil {
+		return nil
+	}
+	if *a != *b {
+		return fmt.Errorf("expected %+v, but got %+v", *a, *b)
+	}
+	return nil
+}
+
 func NewAccountMeta(
 	pubKey PublicKey,
 	WRITE bool,
@@ -173,6 +186,18 @@ func (slice AccountMetaSlice) SplitFrom(index int) (AccountMetaSlice, AccountMet
 	copy(second, slice[index:])
 
 	return first, second
+}
+
+func (a AccountMetaSlice) AssertEquivalent(b AccountMetaSlice) error {
+	for i, acc := range a {
+		if b.Len() < i+1 {
+			return fmt.Errorf("expected account meta at index %d, but got nothing", i)
+		}
+		if err := acc.AssertEquivalent(b[i]); err != nil {
+			return fmt.Errorf("account meta '%d': %w", i, err)
+		}
+	}
+	return nil
 }
 
 func calcSplitAtLengths(total int, index int) (int, int) {

--- a/account.go
+++ b/account.go
@@ -18,6 +18,7 @@
 package solana
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -189,15 +190,18 @@ func (slice AccountMetaSlice) SplitFrom(index int) (AccountMetaSlice, AccountMet
 }
 
 func (a AccountMetaSlice) AssertEquivalent(b AccountMetaSlice) error {
+	var errs []error
 	for i, acc := range a {
 		if b.Len() < i+1 {
-			return fmt.Errorf("expected account meta at index %d, but got nothing", i)
+			errs = append(errs, fmt.Errorf("expected account meta at index '%d', but got nothing", i))
+			continue
 		}
 		if err := acc.AssertEquivalent(b[i]); err != nil {
-			return fmt.Errorf("account meta '%d': %w", i, err)
+			errs = append(errs, fmt.Errorf("account meta '%d': %w", i, err))
+			continue
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func calcSplitAtLengths(total int, index int) (int, int) {

--- a/interface.go
+++ b/interface.go
@@ -21,3 +21,7 @@ type AccountsSettable interface {
 type AccountsGettable interface {
 	GetAccounts() (accounts []*AccountMeta)
 }
+
+type EquivalenceAssertable[T any] interface {
+	AssertEquivalent(T) error
+}

--- a/message.go
+++ b/message.go
@@ -18,7 +18,9 @@
 package solana
 
 import (
+	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	bin "github.com/gagliardetto/binary"
@@ -771,6 +773,98 @@ func (m Message) IsWritable(account PublicKey) (bool, error) {
 		return index-int(h.NumRequiredSignatures) < (m.numStaticAccounts()-int(h.NumRequiredSignatures))-int(h.NumReadonlyUnsignedAccounts), nil
 	}
 	return index < int(h.NumRequiredSignatures-h.NumReadonlySignedAccounts), nil
+}
+
+// AssertEquivalent is essentially an equality check, but it operates on
+// decoded instructions (where possible) which gives useful failures that
+// identify how messages differ, and will allow for differences in transaction
+// version.
+func (a Message) AssertEquivalent(b Message) error {
+	ins, err := a.DecodeInstructions()
+	if err != nil {
+		return err
+	}
+	for i, ain := range ins {
+		if len(b.Instructions) < i+1 {
+			return fmt.Errorf("not equivalent: instruction %d: expected '%T', but got nothing", i, ain)
+		}
+		bin, err := b.DecodeInstruction(b.Instructions[i])
+		if err != nil {
+			return err
+		}
+		equiv, ok := ain.(EquivalenceAssertable[Instruction])
+		if !ok {
+			if err := CheckInstructionEquivalence(ain, bin); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := equiv.AssertEquivalent(bin); err != nil {
+			return fmt.Errorf("not equivalent: instruction '%d': %w", i, err)
+		}
+	}
+	// TODO: Also check other fields.
+	return nil
+}
+
+func (a Message) IsEquivalent(b Message) bool {
+	if err := a.AssertEquivalent(b); err != nil {
+		return false
+	}
+	return true
+}
+
+func (m Message) DecodeInstruction(cin CompiledInstruction) (Instruction, error) {
+	pid, err := m.Program(cin.ProgramIDIndex)
+	if err != nil {
+		return nil, err
+	}
+	accs, err := cin.ResolveInstructionAccounts(&m)
+	if err != nil {
+		return nil, err
+	}
+	in, err := DecodeInstruction(pid, accs, cin.Data)
+	if err != nil {
+		return nil, err
+	}
+	return in.(Instruction), nil
+}
+
+func (m Message) DecodeInstructions() ([]Instruction, error) {
+	ins := make([]Instruction, 0, len(m.Instructions))
+	for _, cin := range m.Instructions {
+		in, err := m.DecodeInstruction(cin)
+		if err != nil {
+			return nil, err
+		}
+		ins = append(ins, in)
+	}
+	return ins, nil
+}
+
+// CheckInstructionEquivalence is the fallback equivalence checking logic
+// which doesn't give as good errors because it compares compiled instruction
+// data.
+func CheckInstructionEquivalence(a, b Instruction) error {
+	if !a.ProgramID().Equals(b.ProgramID()) {
+		return fmt.Errorf("expected programID: %q, but got %q", a.ProgramID(), b.ProgramID())
+	}
+	if err := AccountMetaSlice(a.Accounts()).
+		AssertEquivalent(b.Accounts()); err != nil {
+		return fmt.Errorf("accounts: %w", err)
+	}
+	adata, err := a.Data()
+	if err != nil {
+		return err
+	}
+	bdata, err := b.Data()
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(adata, bdata) {
+		return errors.New("data isn't equal")
+	}
+	return nil
 }
 
 func (m Message) signerKeys() []PublicKey {

--- a/programs/associated-token-account/Create.go
+++ b/programs/associated-token-account/Create.go
@@ -198,6 +198,17 @@ func (inst *Create) UnmarshalWithDecoder(decoder *bin.Decoder) error {
 	return nil
 }
 
+func (a *Create) AssertEquivalent(in interface{}) error {
+	b, ok := in.(*Create)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	if err := a.AccountMetaSlice.AssertEquivalent(b.AccountMetaSlice); err != nil {
+		return fmt.Errorf("(%T) accounts: %w", a, err)
+	}
+	return nil
+}
+
 func NewCreateInstruction(
 	payer solana.PublicKey,
 	walletAddress solana.PublicKey,

--- a/programs/associated-token-account/instructions.go
+++ b/programs/associated-token-account/instructions.go
@@ -70,6 +70,18 @@ func (inst *Instruction) Data() ([]byte, error) {
 	return []byte{}, nil
 }
 
+func (a *Instruction) AssertEquivalent(in solana.Instruction) error {
+	b, ok := in.(*Instruction)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	equiv, ok := a.BaseVariant.Impl.(solana.EquivalenceAssertable[interface{}])
+	if !ok {
+		return solana.CheckInstructionEquivalence(a, b)
+	}
+	return equiv.AssertEquivalent(b.BaseVariant.Impl)
+}
+
 func (inst *Instruction) TextEncode(encoder *text.Encoder, option *text.Option) error {
 	return encoder.Encode(inst.Impl, option)
 }

--- a/programs/compute-budget/SetComputeUnitLimit.go
+++ b/programs/compute-budget/SetComputeUnitLimit.go
@@ -16,6 +16,7 @@ package computebudget
 
 import (
 	"errors"
+	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
 	ag_solanago "github.com/gagliardetto/solana-go"
@@ -108,6 +109,17 @@ func (obj *SetComputeUnitLimit) UnmarshalWithDecoder(decoder *ag_binary.Decoder)
 	err = decoder.Decode(&obj.Units)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func (a *SetComputeUnitLimit) AssertEquivalent(in interface{}) error {
+	b, ok := in.(*SetComputeUnitLimit)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	if a.Units != b.Units {
+		return fmt.Errorf("(%T) expected '%d' units, but got '%d'", a, a.Units, b.Units)
 	}
 	return nil
 }

--- a/programs/compute-budget/SetComputeUnitPrice.go
+++ b/programs/compute-budget/SetComputeUnitPrice.go
@@ -16,6 +16,7 @@ package computebudget
 
 import (
 	"errors"
+	"fmt"
 
 	ag_binary "github.com/gagliardetto/binary"
 	ag_solanago "github.com/gagliardetto/solana-go"
@@ -102,6 +103,17 @@ func (obj *SetComputeUnitPrice) UnmarshalWithDecoder(decoder *ag_binary.Decoder)
 	err = decoder.Decode(&obj.MicroLamports)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func (a *SetComputeUnitPrice) AssertEquivalent(in interface{}) error {
+	b, ok := in.(*SetComputeUnitPrice)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	if a.MicroLamports != b.MicroLamports {
+		return fmt.Errorf("(%T) expected '%d' microLamports, but got '%d'", a, a.MicroLamports, b.MicroLamports)
 	}
 	return nil
 }

--- a/programs/compute-budget/instruction.go
+++ b/programs/compute-budget/instruction.go
@@ -121,6 +121,18 @@ func (inst *Instruction) Data() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func (a *Instruction) AssertEquivalent(in ag_solanago.Instruction) error {
+	b, ok := in.(*Instruction)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	equiv, ok := a.BaseVariant.Impl.(ag_solanago.EquivalenceAssertable[interface{}])
+	if !ok {
+		return ag_solanago.CheckInstructionEquivalence(a, b)
+	}
+	return equiv.AssertEquivalent(b.BaseVariant.Impl)
+}
+
 func (inst *Instruction) TextEncode(encoder *ag_text.Encoder, option *ag_text.Option) error {
 	return encoder.Encode(inst.Impl, option)
 }

--- a/programs/system/Transfer.go
+++ b/programs/system/Transfer.go
@@ -150,6 +150,20 @@ func (inst *Transfer) UnmarshalWithDecoder(decoder *ag_binary.Decoder) error {
 	return nil
 }
 
+func (a *Transfer) AssertEquivalent(in interface{}) error {
+	b, ok := in.(*Transfer)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	if *a.Lamports != *b.Lamports {
+		return fmt.Errorf("(%T) expected '%d' lamports, but got '%d'", a, *a.Lamports, *b.Lamports)
+	}
+	if err := a.AccountMetaSlice.AssertEquivalent(b.AccountMetaSlice); err != nil {
+		return fmt.Errorf("(%T) accounts: %w", a, err)
+	}
+	return nil
+}
+
 // NewTransferInstruction declares a new Transfer instruction with the provided parameters and accounts.
 func NewTransferInstruction(
 	// Parameters:

--- a/programs/system/Transfer_test.go
+++ b/programs/system/Transfer_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	ag_gofuzz "github.com/gagliardetto/gofuzz"
+	ag_solanago "github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
 	ag_require "github.com/stretchr/testify/require"
 )
 
@@ -43,4 +45,27 @@ func TestEncodeDecode_Transfer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTransfer_AssertEquivalent(t *testing.T) {
+	tx1, err := ag_solanago.NewTransaction([]ag_solanago.Instruction{
+		NewTransferInstruction(
+			1,
+			ag_solanago.PK{},
+			ag_solanago.PK{},
+		).Build(),
+	}, ag_solanago.Hash{})
+	require.NoError(t, err)
+
+	require.NoError(t, tx1.Message.AssertEquivalent(tx1.Message))
+
+	tx2, err := ag_solanago.NewTransaction([]ag_solanago.Instruction{
+		NewTransferInstruction(
+			2,
+			ag_solanago.PK{},
+			ag_solanago.PK{},
+		).Build(),
+	}, ag_solanago.Hash{}, ag_solanago.TransactionPayer(ag_solanago.PK{}))
+
+	require.Error(t, tx1.Message.AssertEquivalent(tx2.Message))
 }

--- a/programs/system/instructions.go
+++ b/programs/system/instructions.go
@@ -182,6 +182,18 @@ func (inst *Instruction) Data() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func (a *Instruction) AssertEquivalent(in ag_solanago.Instruction) error {
+	b, ok := in.(*Instruction)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	equiv, ok := a.BaseVariant.Impl.(ag_solanago.EquivalenceAssertable[interface{}])
+	if !ok {
+		return ag_solanago.CheckInstructionEquivalence(a, b)
+	}
+	return equiv.AssertEquivalent(b.BaseVariant.Impl)
+}
+
 func (inst *Instruction) TextEncode(encoder *ag_text.Encoder, option *ag_text.Option) error {
 	return encoder.Encode(inst.Impl, option)
 }

--- a/programs/token/CloseAccount.go
+++ b/programs/token/CloseAccount.go
@@ -184,6 +184,20 @@ func (obj *CloseAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err e
 	return nil
 }
 
+func (a *CloseAccount) AssertEquivalent(in interface{}) error {
+	b, ok := in.(*CloseAccount)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	if err := a.Accounts.AssertEquivalent(b.Accounts); err != nil {
+		return fmt.Errorf("(%T) accounts: %w", a, err)
+	}
+	if err := a.Signers.AssertEquivalent(b.Signers); err != nil {
+		return fmt.Errorf("(%T) signers: %w", a, err)
+	}
+	return nil
+}
+
 // NewCloseAccountInstruction declares a new CloseAccount instruction with the provided parameters and accounts.
 func NewCloseAccountInstruction(
 	// Accounts:

--- a/programs/token/Transfer.go
+++ b/programs/token/Transfer.go
@@ -214,6 +214,23 @@ func (obj *Transfer) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error
 	return nil
 }
 
+func (a *Transfer) AssertEquivalent(in interface{}) error {
+	b, ok := in.(*Transfer)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	if *a.Amount != *b.Amount {
+		return fmt.Errorf("(%T) expected '%d' amount, but got '%d'", a, *a.Amount, *b.Amount)
+	}
+	if err := a.Accounts.AssertEquivalent(b.Accounts); err != nil {
+		return fmt.Errorf("(%T) accounts: %w", a, err)
+	}
+	if err := a.Signers.AssertEquivalent(b.Signers); err != nil {
+		return fmt.Errorf("(%T) signers: %w", a, err)
+	}
+	return nil
+}
+
 // NewTransferInstruction declares a new Transfer instruction with the provided parameters and accounts.
 func NewTransferInstruction(
 	// Parameters:

--- a/programs/token/TransferChecked.go
+++ b/programs/token/TransferChecked.go
@@ -262,6 +262,26 @@ func (obj *TransferChecked) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (er
 	return nil
 }
 
+func (a *TransferChecked) AssertEquivalent(in interface{}) error {
+	b, ok := in.(*TransferChecked)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	if *a.Amount != *b.Amount {
+		return fmt.Errorf("(%T) expected '%d' amount, but got '%d'", a, *a.Amount, *b.Amount)
+	}
+	if *a.Decimals != *b.Decimals {
+		return fmt.Errorf("(%T) expected '%d' decimals, but got '%d'", a, *a.Decimals, *b.Decimals)
+	}
+	if err := a.Accounts.AssertEquivalent(b.Accounts); err != nil {
+		return fmt.Errorf("(%T) accounts: %w", a, err)
+	}
+	if err := a.Signers.AssertEquivalent(b.Signers); err != nil {
+		return fmt.Errorf("(%T) signers: %w", a, err)
+	}
+	return nil
+}
+
 // NewTransferCheckedInstruction declares a new TransferChecked instruction with the provided parameters and accounts.
 func NewTransferCheckedInstruction(
 	// Parameters:

--- a/programs/token/instructions.go
+++ b/programs/token/instructions.go
@@ -323,6 +323,18 @@ func (inst *Instruction) Data() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func (a *Instruction) AssertEquivalent(in ag_solanago.Instruction) error {
+	b, ok := in.(*Instruction)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	equiv, ok := a.BaseVariant.Impl.(ag_solanago.EquivalenceAssertable[interface{}])
+	if !ok {
+		return ag_solanago.CheckInstructionEquivalence(a, b)
+	}
+	return equiv.AssertEquivalent(b.BaseVariant.Impl)
+}
+
 func (inst *Instruction) TextEncode(encoder *ag_text.Encoder, option *ag_text.Option) error {
 	return encoder.Encode(inst.Impl, option)
 }

--- a/programs/token2022/CloseAccount.go
+++ b/programs/token2022/CloseAccount.go
@@ -184,6 +184,20 @@ func (obj *CloseAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err e
 	return nil
 }
 
+func (a *CloseAccount) AssertEquivalent(in interface{}) error {
+	b, ok := in.(*CloseAccount)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	if err := a.Accounts.AssertEquivalent(b.Accounts); err != nil {
+		return fmt.Errorf("(%T) accounts: %w", a, err)
+	}
+	if err := a.Signers.AssertEquivalent(b.Signers); err != nil {
+		return fmt.Errorf("(%T) signers: %w", a, err)
+	}
+	return nil
+}
+
 // NewCloseAccountInstruction declares a new CloseAccount instruction with the provided parameters and accounts.
 func NewCloseAccountInstruction(
 	// Accounts:

--- a/programs/token2022/Transfer.go
+++ b/programs/token2022/Transfer.go
@@ -214,6 +214,23 @@ func (obj *Transfer) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error
 	return nil
 }
 
+func (a *Transfer) AssertEquivalent(in interface{}) error {
+	b, ok := in.(*Transfer)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	if *a.Amount != *b.Amount {
+		return fmt.Errorf("(%T) expected '%d' amount, but got '%d'", a, *a.Amount, *b.Amount)
+	}
+	if err := a.Accounts.AssertEquivalent(b.Accounts); err != nil {
+		return fmt.Errorf("(%T) accounts: %w", a, err)
+	}
+	if err := a.Signers.AssertEquivalent(b.Signers); err != nil {
+		return fmt.Errorf("(%T) signers: %w", a, err)
+	}
+	return nil
+}
+
 // NewTransferInstruction declares a new Transfer instruction with the provided parameters and accounts.
 func NewTransferInstruction(
 	// Parameters:

--- a/programs/token2022/TransferChecked.go
+++ b/programs/token2022/TransferChecked.go
@@ -262,6 +262,26 @@ func (obj *TransferChecked) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (er
 	return nil
 }
 
+func (a *TransferChecked) AssertEquivalent(in interface{}) error {
+	b, ok := in.(*TransferChecked)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	if *a.Amount != *b.Amount {
+		return fmt.Errorf("(%T) expected '%d' amount, but got '%d'", a, *a.Amount, *b.Amount)
+	}
+	if *a.Decimals != *b.Decimals {
+		return fmt.Errorf("(%T) expected '%d' decimals, but got '%d'", a, *a.Decimals, *b.Decimals)
+	}
+	if err := a.Accounts.AssertEquivalent(b.Accounts); err != nil {
+		return fmt.Errorf("(%T) accounts: %w", a, err)
+	}
+	if err := a.Signers.AssertEquivalent(b.Signers); err != nil {
+		return fmt.Errorf("(%T) signers: %w", a, err)
+	}
+	return nil
+}
+
 // NewTransferCheckedInstruction declares a new TransferChecked instruction with the provided parameters and accounts.
 func NewTransferCheckedInstruction(
 	// Parameters:

--- a/programs/token2022/instructions.go
+++ b/programs/token2022/instructions.go
@@ -323,6 +323,18 @@ func (inst *Instruction) Data() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func (a *Instruction) AssertEquivalent(in ag_solanago.Instruction) error {
+	b, ok := in.(*Instruction)
+	if !ok {
+		return fmt.Errorf("expected %T, but got %T", a, in)
+	}
+	equiv, ok := a.BaseVariant.Impl.(ag_solanago.EquivalenceAssertable[interface{}])
+	if !ok {
+		return ag_solanago.CheckInstructionEquivalence(a, b)
+	}
+	return equiv.AssertEquivalent(b.BaseVariant.Impl)
+}
+
 func (inst *Instruction) TextEncode(encoder *ag_text.Encoder, option *ag_text.Option) error {
 	return encoder.Encode(inst.Impl, option)
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -45,6 +45,10 @@ func (t *testTransactionInstructions) Data() ([]byte, error) {
 	return t.data, nil
 }
 
+func (*testTransactionInstructions) AssertEquivalent(Instruction) error {
+	panic("unimplemented")
+}
+
 func TestNewTransaction(t *testing.T) {
 	debugNewTransaction = true
 


### PR DESCRIPTION
This PR introduces a mechanism to assert the equivalence of solana transaction messages. This is intended to be used as an alternative to a straight byte comparison of transactions because a byte comparison is susceptible for finding differences that don't really matter, for example with transaction encoding versions. Byte comparisons also don't give an indication of how the transactions differ, whereas the equivalence assertions will point out where the differences occur.

I've built this in a way that if an instruction doesn't implement `EquivalenceAssertable` then a fallback byte comparison is performed. This means that the assertion will work for unknown instruction types, though will give less useful errors. This also means that I don't have to implement the comparison for all instruction types provided by this library 😅 