### PR TITLE
Replace placeholder signatures (if present)

### DIFF
--- a/transaction_test.go
+++ b/transaction_test.go
@@ -191,6 +191,24 @@ func TestSignTransaction(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, len(signatures), 2)
 	})
+
+	t.Run("should replace placeholder signatures", func(t *testing.T) {
+		// Replace signatures with 'null' placeholders.
+		trx.Signatures[0] = Signature{}
+		trx.Signatures[1] = Signature{}
+		signatures, err := trx.PartialSign(func(key PublicKey) *PrivateKey {
+			if key.Equals(signers[1].PublicKey()) {
+				return &signers[1]
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, len(trx.Signatures), 2)
+		// Assert first placeholder ignored.
+		assert.True(t, trx.Signatures[0].IsZero())
+		// Assert second placeholder replaced with signature.
+		assert.Equal(t, trx.Signatures[1], signatures[1])
+	})
 }
 
 func TestTransactionDecode(t *testing.T) {


### PR DESCRIPTION
Some libraries construct transactions with null placeholders for missing, required, signatures (web). This breaks partially signing transactions because the current implementation just appends all signatures to the end of the slice (so we end up with too many).

With this change, if the number of required signatures has been provided, and the signature at a given index `.IsZero` (which is a zeroed `[64]byte`), then we'll replace it with our signature rather than appending our signature to the end.

This isn't fool proof - it does mean that if there's already a (non-zero) signature at the index we're expecting to add our signature, then we'll append ours. This would break things in the case that `PartialSign` is called twice - but that's not a change to the current behaviour of the library so I think it's fine.