### PR TITLE
Make HTTPError implement errors.Unwrap

### DIFF
--- a/rpc/jsonrpc/jsonrpc.go
+++ b/rpc/jsonrpc/jsonrpc.go
@@ -240,6 +240,8 @@ type HTTPError struct {
 	err  error
 }
 
+var _ error = (*HTTPError)(nil)
+
 // HTTPClient is an abstraction for a HTTP client
 type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
@@ -256,6 +258,11 @@ func NewHTTPError(code int, err error) *HTTPError {
 // Error function is provided to be used as error object.
 func (e *HTTPError) Error() string {
 	return e.err.Error()
+}
+
+// Unwrap returns the underlying error.
+func (res HTTPError) Unwrap() error {
+	return res.err
 }
 
 type rpcClient struct {


### PR DESCRIPTION
By implementing this receiver method, we can handler errors in a better way in our app by calling `errors.Is` and `errors.As`.

This was prompted by this error:
https://avianlabsworkspace.slack.com/archives/C04LUCJ6527/p1713449826388919