### PR TITLE
Add associatedtokenaccount CreateIdempotent option

### DIFF
--- a/programs/associated-token-account/Create_test.go
+++ b/programs/associated-token-account/Create_test.go
@@ -1,0 +1,76 @@
+package associatedtokenaccount
+
+import (
+	"testing"
+
+	bin "github.com/gagliardetto/binary"
+	solana "github.com/gagliardetto/solana-go"
+	"github.com/test-go/testify/assert"
+	"github.com/test-go/testify/require"
+)
+
+func TestCreateNonIdempotentData(t *testing.T) {
+	t.Parallel()
+	wallet, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+
+	c := NewCreateInstruction(
+		wallet.PublicKey(),
+		wallet.PublicKey(),
+		solana.MPK("G8iheDY9bGix5qCXEitCExLcgZzZrEemngk9cbTR3CQs"),
+		solana.MustPublicKeyFromBase58("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"),
+		false,
+	)
+
+	data, err := c.Build().Data()
+	require.NoError(t, err)
+
+	assert.Len(t, data, 0)
+}
+
+func TestCreateIdempotentData(t *testing.T) {
+	t.Parallel()
+	wallet, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+
+	c := NewCreateInstruction(
+		wallet.PublicKey(),
+		wallet.PublicKey(),
+		solana.MPK("G8iheDY9bGix5qCXEitCExLcgZzZrEemngk9cbTR3CQs"),
+		solana.MustPublicKeyFromBase58("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"),
+		true,
+	)
+
+	data, err := c.Build().Data()
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte{1}, data)
+}
+
+func TestEncodeRoundtrip(t *testing.T) {
+	t.Parallel()
+	wallet, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+
+	c := NewCreateInstruction(
+		wallet.PublicKey(),
+		wallet.PublicKey(),
+		solana.MPK("G8iheDY9bGix5qCXEitCExLcgZzZrEemngk9cbTR3CQs"),
+		solana.MustPublicKeyFromBase58("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"),
+		true,
+	).Build()
+
+	blockhash := solana.MustHashFromBase58("AnL7vVGidfdxZBFqkxLvVwXgW9pDSZC5kK6d5kyRaXEa")
+	tx, err := solana.NewTransaction([]solana.Instruction{c}, blockhash)
+	require.NoError(t, err)
+
+	data, err := tx.MarshalBinary()
+	require.NoError(t, err)
+
+	decoded := &solana.Transaction{}
+	err = decoded.UnmarshalWithDecoder(bin.NewCompactU16Decoder(data))
+	require.NoError(t, err)
+
+	err = tx.Message.AssertEquivalent(decoded.Message)
+	require.NoError(t, err)
+}

--- a/programs/associated-token-account/instructions.go
+++ b/programs/associated-token-account/instructions.go
@@ -15,9 +15,11 @@
 package associatedtokenaccount
 
 import (
+	"bytes"
 	"fmt"
 
 	spew "github.com/davecgh/go-spew/spew"
+	ag_binary "github.com/gagliardetto/binary"
 	bin "github.com/gagliardetto/binary"
 	solana "github.com/gagliardetto/solana-go"
 	text "github.com/gagliardetto/solana-go/text"
@@ -67,7 +69,11 @@ func (inst *Instruction) Accounts() (out []*solana.AccountMeta) {
 }
 
 func (inst *Instruction) Data() ([]byte, error) {
-	return []byte{}, nil
+	buf := new(bytes.Buffer)
+	if err := ag_binary.NewBinEncoder(buf).Encode(inst); err != nil {
+		return nil, fmt.Errorf("unable to encode instruction: %w", err)
+	}
+	return buf.Bytes(), nil
 }
 
 func (a *Instruction) AssertEquivalent(in solana.Instruction) error {


### PR DESCRIPTION
The associated token account program can idempotently create the account if the value []byte{1} is passed in the data field. This PR updates the create instruction to support creating idempotently.