### PR TITLE
allow setting minimum context slot when checking blockhash validity

### DIFF
--- a/rpc/isBlockhashValid.go
+++ b/rpc/isBlockhashValid.go
@@ -6,6 +6,15 @@ import (
 	"github.com/gagliardetto/solana-go"
 )
 
+type IsBlockhashValidOpts struct {
+	// Commitment (optional) level to check for validity for.
+	Commitment CommitmentType
+
+	// MinContextSlot (optional) is the minimum slot that the request can be
+	// evaulated at.
+	MinContextSlot *uint64
+}
+
 // Returns whether a blockhash is still valid or not
 //
 // **NEW: This method is only available in solana-core v1.9 or newer. Please use
@@ -18,9 +27,29 @@ func (cl *Client) IsBlockhashValid(
 	// Commitment requirement. Optional.
 	commitment CommitmentType,
 ) (out *IsValidBlockhashResult, err error) {
+	return cl.IsBlockhashValidWithOpts(
+		ctx, blockHash, IsBlockhashValidOpts{
+			Commitment: commitment,
+		},
+	)
+}
+
+// Returns whether a blockhash is still valid or not
+//
+// **NEW: This method is only available in solana-core v1.9 or newer. Please use
+// `getFeeCalculatorForBlockhash` for solana-core v1.8**
+func (cl *Client) IsBlockhashValidWithOpts(
+	ctx context.Context,
+	// Blockhash to be queried. Required.
+	blockHash solana.Hash,
+	opts IsBlockhashValidOpts,
+) (out *IsValidBlockhashResult, err error) {
 	params := []interface{}{blockHash}
-	if commitment != "" {
-		params = append(params, M{"commitment": string(commitment)})
+	if opts.Commitment != "" {
+		params = append(params, M{"commitment": string(opts.Commitment)})
+	}
+	if opts.MinContextSlot != nil {
+		params = append(params, M{"minContextSlot": *opts.MinContextSlot})
 	}
 
 	err = cl.rpcClient.CallForInto(ctx, &out, "isBlockhashValid", params)


### PR DESCRIPTION
The documentation documents this param, but currently our rpc client doesn't allow it to be passed. I've tried to follow the structure of other methods where there's a basic implementation, and another which takes additional options.

Documentation here: https://solana.com/docs/rpc/http/isblockhashvalid