### PR TITLE
add `minContextSlot` as an option when simulating transactions

### DIFF
--- a/rpc/simulateTransaction.go
+++ b/rpc/simulateTransaction.go
@@ -72,6 +72,9 @@ type SimulateTransactionOpts struct {
 	ReplaceRecentBlockhash bool
 
 	Accounts *SimulateTransactionAccountsOpts
+
+	// The minimum slot the request can be evaluated at.
+	MinContextSlot *uint64
 }
 
 type SimulateTransactionAccountsOpts struct {
@@ -124,6 +127,9 @@ func (cl *Client) SimulateRawTransactionWithOpts(
 				"encoding":  opts.Accounts.Encoding,
 				"addresses": opts.Accounts.Addresses,
 			}
+		}
+		if opts.MinContextSlot != nil {
+			obj["minContextSlot"] = *opts.MinContextSlot
 		}
 	}
 


### PR DESCRIPTION
As documented here: https://solana.com/docs/rpc/http/simulatetransaction#parameters