### PR TITLE
Return raw response bytes from 'getTransaction'

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -2302,7 +2302,7 @@ func TestClient_GetTransaction(t *testing.T) {
 		Commitment:                     CommitmentMax,
 		MaxSupportedTransactionVersion: &maxSupportedTransactionVersion,
 	}
-	out, err := client.GetTransaction(
+	out, _, err := client.GetTransaction(
 		context.Background(),
 		solana.MustSignatureFromBase58(tx),
 		&opts,

--- a/rpc/examples/getTransaction/getTransaction.go
+++ b/rpc/examples/getTransaction/getTransaction.go
@@ -29,7 +29,7 @@ func main() {
 
 	txSig := solana.MustSignatureFromBase58("4bjVLV1g9SAfv7BSAdNnuSPRbSscADHFe4HegL6YVcuEBMY83edLEvtfjE4jfr6rwdLwKBQbaFiGgoLGtVicDzHq")
 	{
-		out, err := client.GetTransaction(
+		out, _, err := client.GetTransaction(
 			context.TODO(),
 			txSig,
 			nil,
@@ -41,7 +41,7 @@ func main() {
 		spew.Dump(out.Transaction.GetTransaction())
 	}
 	{
-		out, err := client.GetTransaction(
+		out, _, err := client.GetTransaction(
 			context.TODO(),
 			txSig,
 			&rpc.GetTransactionOpts{
@@ -55,7 +55,7 @@ func main() {
 		spew.Dump(out.Transaction.GetTransaction())
 	}
 	{
-		out, err := client.GetTransaction(
+		out, _, err := client.GetTransaction(
 			context.TODO(),
 			txSig,
 			&rpc.GetTransactionOpts{
@@ -69,7 +69,7 @@ func main() {
 		spew.Dump(out.Transaction.GetBinary())
 	}
 	{
-		out, err := client.GetTransaction(
+		out, _, err := client.GetTransaction(
 			context.TODO(),
 			txSig,
 			&rpc.GetTransactionOpts{

--- a/rpc/getTransaction.go
+++ b/rpc/getTransaction.go
@@ -41,7 +41,7 @@ func (cl *Client) GetTransaction(
 	ctx context.Context,
 	txSig solana.Signature, // transaction signature
 	opts *GetTransactionOpts,
-) (out *GetTransactionResult, err error) {
+) (out *GetTransactionResult, bytes []byte, err error) {
 	params := []interface{}{txSig}
 	if opts != nil {
 		obj := M{}
@@ -55,7 +55,7 @@ func (cl *Client) GetTransaction(
 				solana.EncodingBase64,
 				solana.EncodingBase64Zstd,
 			) {
-				return nil, fmt.Errorf("provided encoding is not supported: %s", opts.Encoding)
+				return nil, nil, fmt.Errorf("provided encoding is not supported: %s", opts.Encoding)
 			}
 			obj["encoding"] = opts.Encoding
 		}
@@ -71,12 +71,12 @@ func (cl *Client) GetTransaction(
 	}
 	err = cl.rpcClient.CallForInto(ctx, &out, "getTransaction", params)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if out == nil {
-		return nil, ErrNotFound
+		return nil, nil, ErrNotFound
 	}
-
+	bytes, _ = json.Marshal(out)
 	if out.Meta.Err == nil {
 		return
 	}


### PR DESCRIPTION
So that we can persist it alongside Solana transaction transitions.

I don't just want to re-encode the response in the caller because we're fiddling with the structure of it when we decode solana transactions.