### PR TITLE
Accept ATA Create instructions without the rent sysvar

### DIFF
--- a/message.go
+++ b/message.go
@@ -868,19 +868,44 @@ func (a Message) IsEquivalent(b Message) bool {
 
 func (a Message) assertEquivalent(b Message) error {
 	var errs []error
+	// The rent sysvar is no longer required by the associated token account
+	// program's Create instruction, so newer client libraries omit it while
+	// older ones still include it. When exactly one message references the
+	// rent sysvar as a read-only unsigned account, tolerate the difference:
+	// skip it in the account-key comparison and exclude it from the
+	// read-only unsigned header count. The account is a fixed-address,
+	// read-only sysvar, so its presence or absence cannot change what the
+	// transaction is able to do.
+	tolerateRent := a.hasStaticReadonlyUnsignedRent() != b.hasStaticReadonlyUnsignedRent()
 	// Assert all accounts in a are in b (but agnostic on ordering).
 	for _, accKey := range a.AccountKeys {
+		if tolerateRent && accKey.Equals(SysVarRentPubkey) {
+			continue
+		}
 		if !containsAccount(b.AccountKeys, accKey) {
 			errs = append(errs, fmt.Errorf("account keys: %q not found", accKey))
 		}
 	}
 	// Assert all accounts in b are in a (but agnostic on ordering).
 	for _, accKey := range b.AccountKeys {
+		if tolerateRent && accKey.Equals(SysVarRentPubkey) {
+			continue
+		}
 		if !containsAccount(a.AccountKeys, accKey) {
 			errs = append(errs, fmt.Errorf("account keys: unexpected account %q found", accKey))
 		}
 	}
-	if err := a.Header.AssertEquivalent(b.Header); err != nil {
+	aHeader, bHeader := a.Header, b.Header
+	if tolerateRent {
+		// Exactly one side counts the rent sysvar among its read-only
+		// unsigned accounts; exclude it so the remaining counts compare.
+		if a.hasStaticReadonlyUnsignedRent() {
+			aHeader.NumReadonlyUnsignedAccounts--
+		} else {
+			bHeader.NumReadonlyUnsignedAccounts--
+		}
+	}
+	if err := aHeader.AssertEquivalent(bHeader); err != nil {
 		errs = append(errs, fmt.Errorf("header: %w", err))
 	}
 	if !a.RecentBlockhash.Equals(b.RecentBlockhash) {
@@ -1009,6 +1034,26 @@ func (a MessageHeader) AssertEquivalent(b MessageHeader) error {
 		))
 	}
 	return errors.Join(errs...)
+}
+
+// hasStaticReadonlyUnsignedRent reports whether the rent sysvar appears among
+// the message's static account keys within the read-only unsigned region
+// described by the header. This is the only placement a benign transaction
+// gives the rent sysvar (it can never sign and must never be writable), and
+// it is the placement assertEquivalent tolerates being present on one side
+// only.
+func (m Message) hasStaticReadonlyUnsignedRent() bool {
+	numStatic := m.numStaticAccounts()
+	firstReadonlyUnsigned := numStatic - int(m.Header.NumReadonlyUnsignedAccounts)
+	if firstReadonlyUnsigned < 0 {
+		firstReadonlyUnsigned = 0
+	}
+	for idx := firstReadonlyUnsigned; idx < numStatic && idx < len(m.AccountKeys); idx++ {
+		if m.AccountKeys[idx].Equals(SysVarRentPubkey) {
+			return true
+		}
+	}
+	return false
 }
 
 func containsAccount(accountKeys []PublicKey, accountKey PublicKey) bool {

--- a/programs/associated-token-account/Create.go
+++ b/programs/associated-token-account/Create.go
@@ -218,13 +218,64 @@ func (inst *Create) UnmarshalWithDecoder(decoder *bin.Decoder) error {
 	return nil
 }
 
+// requiredCreateAccounts is the number of accounts a Create instruction must
+// reference: payer, associated token account, wallet, mint, system program,
+// and token program. The rent sysvar used to follow as a seventh account but
+// is no longer required by the associated token account program, so newer
+// client libraries omit it and equivalence treats it as optional.
+const requiredCreateAccounts = 6
+
 func (a *Create) AssertEquivalent(in interface{}) error {
 	b, ok := in.(*Create)
 	if !ok {
 		return fmt.Errorf("expected %T, but got %T", a, in)
 	}
-	if err := a.AccountMetaSlice.AssertEquivalent(b.AccountMetaSlice); err != nil {
+	if err := assertCreateAccountsEquivalent(a.AccountMetaSlice, b.AccountMetaSlice); err != nil {
 		return fmt.Errorf("(%T) accounts: %w", a, err)
+	}
+	return nil
+}
+
+// assertCreateAccountsEquivalent compares the account lists of two Create
+// instructions. The six required accounts are compared strictly; the trailing
+// rent sysvar account may be present or absent on either side independently,
+// but when present it must be exactly the read-only, non-signer rent sysvar.
+func assertCreateAccountsEquivalent(a, b solana.AccountMetaSlice) error {
+	var errs []error
+	limit := len(a)
+	if limit > requiredCreateAccounts {
+		limit = requiredCreateAccounts
+	}
+	for i, acc := range a[:limit] {
+		if b.Len() < i+1 {
+			errs = append(errs, fmt.Errorf("expected account meta at index '%d', but got nothing", i))
+			continue
+		}
+		if err := acc.AssertEquivalent(b[i]); err != nil {
+			errs = append(errs, fmt.Errorf("account meta '%d': %w", i, err))
+		}
+	}
+	if err := assertOptionalRentMeta(a); err != nil {
+		errs = append(errs, err)
+	}
+	if err := assertOptionalRentMeta(b); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// assertOptionalRentMeta checks that any account beyond the six required ones
+// is a single read-only, non-signer rent sysvar meta.
+func assertOptionalRentMeta(metas solana.AccountMetaSlice) error {
+	if len(metas) <= requiredCreateAccounts {
+		return nil
+	}
+	if len(metas) > requiredCreateAccounts+1 {
+		return fmt.Errorf("expected at most %d account metas, but got %d", requiredCreateAccounts+1, len(metas))
+	}
+	want := &solana.AccountMeta{PublicKey: solana.SysVarRentPubkey}
+	if err := want.AssertEquivalent(metas[requiredCreateAccounts]); err != nil {
+		return fmt.Errorf("account meta '%d' (rent sysvar): %w", requiredCreateAccounts, err)
 	}
 	return nil
 }

--- a/programs/associated-token-account/Create_test.go
+++ b/programs/associated-token-account/Create_test.go
@@ -74,3 +74,173 @@ func TestEncodeRoundtrip(t *testing.T) {
 	err = tx.Message.AssertEquivalent(decoded.Message)
 	require.NoError(t, err)
 }
+
+// buildCreateWithoutRent builds a Create instruction in the modern format
+// which omits the rent sysvar account (as emitted by newer client libraries
+// such as solana-kotlin).
+func buildCreateWithoutRent(
+	t *testing.T,
+	payer, wallet, mint, tokenProgramID solana.PublicKey,
+	idempotent bool,
+) *Instruction {
+	t.Helper()
+	ata, _, err := solana.FindAssociatedTokenAddress(wallet, mint, tokenProgramID)
+	require.NoError(t, err)
+	create := Create{
+		Payer:          payer,
+		Wallet:         wallet,
+		Mint:           mint,
+		TokenProgramID: tokenProgramID,
+		Idempotent:     idempotent,
+	}
+	create.AccountMetaSlice = solana.AccountMetaSlice{
+		solana.NewAccountMeta(payer, true, true),
+		solana.NewAccountMeta(ata, true, false),
+		solana.NewAccountMeta(wallet, false, false),
+		solana.NewAccountMeta(mint, false, false),
+		solana.NewAccountMeta(solana.SystemProgramID, false, false),
+		solana.NewAccountMeta(tokenProgramID, false, false),
+	}
+	return &Instruction{BaseVariant: bin.BaseVariant{
+		Impl:   create,
+		TypeID: bin.NoTypeIDDefaultID,
+	}}
+}
+
+// testCreateKeys returns a deterministic set of keys for equivalence tests.
+func testCreateKeys(t *testing.T) (payer, wallet, mint, tokenProgramID solana.PublicKey) {
+	t.Helper()
+	payerKey, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+	payer = payerKey.PublicKey()
+	wallet = payer
+	mint = solana.MPK("G8iheDY9bGix5qCXEitCExLcgZzZrEemngk9cbTR3CQs")
+	tokenProgramID = solana.TokenProgramID
+	return payer, wallet, mint, tokenProgramID
+}
+
+func TestCreateAssertEquivalentOptionalRent(t *testing.T) {
+	t.Parallel()
+	payer, wallet, mint, tokenProgramID := testCreateKeys(t)
+
+	withRent := NewCreateInstruction(payer, wallet, mint, tokenProgramID, false).Build()
+	withoutRent := buildCreateWithoutRent(t, payer, wallet, mint, tokenProgramID, false)
+
+	withRentImpl := withRent.Impl.(Create)
+	withoutRentImpl := withoutRent.Impl.(Create)
+
+	// Rent present on either side (or both, or neither) is equivalent.
+	assert.NoError(t, withRentImpl.AssertEquivalent(&withoutRentImpl))
+	assert.NoError(t, withoutRentImpl.AssertEquivalent(&withRentImpl))
+	assert.NoError(t, withRentImpl.AssertEquivalent(&withRentImpl))
+	assert.NoError(t, withoutRentImpl.AssertEquivalent(&withoutRentImpl))
+}
+
+func TestCreateAssertEquivalentRejectsBadTrailingAccount(t *testing.T) {
+	t.Parallel()
+	payer, wallet, mint, tokenProgramID := testCreateKeys(t)
+
+	expected := NewCreateInstruction(payer, wallet, mint, tokenProgramID, false).Build().Impl.(Create)
+
+	// A seventh account that is not the rent sysvar must be rejected.
+	notRent := buildCreateWithoutRent(t, payer, wallet, mint, tokenProgramID, false).Impl.(Create)
+	notRent.AccountMetaSlice = append(notRent.AccountMetaSlice,
+		solana.NewAccountMeta(solana.SysVarClockPubkey, false, false))
+	assert.Error(t, expected.AssertEquivalent(&notRent))
+
+	// A writable rent sysvar must be rejected.
+	writableRent := buildCreateWithoutRent(t, payer, wallet, mint, tokenProgramID, false).Impl.(Create)
+	writableRent.AccountMetaSlice = append(writableRent.AccountMetaSlice,
+		solana.NewAccountMeta(solana.SysVarRentPubkey, true, false))
+	assert.Error(t, expected.AssertEquivalent(&writableRent))
+
+	// More than seven accounts must be rejected.
+	extra := NewCreateInstruction(payer, wallet, mint, tokenProgramID, false).Build().Impl.(Create)
+	extra.AccountMetaSlice = append(extra.AccountMetaSlice,
+		solana.NewAccountMeta(solana.SysVarClockPubkey, false, false))
+	assert.Error(t, expected.AssertEquivalent(&extra))
+
+	// A missing required account must still be rejected.
+	truncated := buildCreateWithoutRent(t, payer, wallet, mint, tokenProgramID, false).Impl.(Create)
+	truncated.AccountMetaSlice = truncated.AccountMetaSlice[:5]
+	assert.Error(t, expected.AssertEquivalent(&truncated))
+
+	// A differing required account must still be rejected, with or without rent.
+	otherWallet, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+	differing := buildCreateWithoutRent(t, payer, otherWallet.PublicKey(), mint, tokenProgramID, false).Impl.(Create)
+	assert.Error(t, expected.AssertEquivalent(&differing))
+}
+
+func TestMessageAssertEquivalentToleratesMissingRent(t *testing.T) {
+	t.Parallel()
+	payer, wallet, mint, tokenProgramID := testCreateKeys(t)
+	blockhash := solana.MustHashFromBase58("AnL7vVGidfdxZBFqkxLvVwXgW9pDSZC5kK6d5kyRaXEa")
+
+	expected, err := solana.NewTransaction(
+		[]solana.Instruction{
+			NewCreateInstruction(payer, wallet, mint, tokenProgramID, false).Build(),
+		},
+		blockhash,
+		solana.TransactionPayer(payer),
+	)
+	require.NoError(t, err)
+
+	// Simulate a client-built transaction in the modern rent-less format
+	// arriving over the wire.
+	clientTx, err := solana.NewTransaction(
+		[]solana.Instruction{
+			buildCreateWithoutRent(t, payer, wallet, mint, tokenProgramID, false),
+		},
+		blockhash,
+		solana.TransactionPayer(payer),
+	)
+	require.NoError(t, err)
+	wire, err := clientTx.MarshalBinary()
+	require.NoError(t, err)
+	received := &solana.Transaction{}
+	require.NoError(t, received.UnmarshalWithDecoder(bin.NewCompactU16Decoder(wire)))
+
+	assert.NoError(t, expected.Message.AssertEquivalent(received.Message))
+	assert.NoError(t, received.Message.AssertEquivalent(expected.Message))
+}
+
+func TestMessageAssertEquivalentStillRejectsOtherDifferences(t *testing.T) {
+	t.Parallel()
+	payer, wallet, mint, tokenProgramID := testCreateKeys(t)
+	blockhash := solana.MustHashFromBase58("AnL7vVGidfdxZBFqkxLvVwXgW9pDSZC5kK6d5kyRaXEa")
+
+	expected, err := solana.NewTransaction(
+		[]solana.Instruction{
+			NewCreateInstruction(payer, wallet, mint, tokenProgramID, false).Build(),
+		},
+		blockhash,
+		solana.TransactionPayer(payer),
+	)
+	require.NoError(t, err)
+
+	// A rent-less transaction for a different wallet must still fail even
+	// though the rent difference itself is tolerated.
+	otherWallet, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+	differing, err := solana.NewTransaction(
+		[]solana.Instruction{
+			buildCreateWithoutRent(t, payer, otherWallet.PublicKey(), mint, tokenProgramID, false),
+		},
+		blockhash,
+		solana.TransactionPayer(payer),
+	)
+	require.NoError(t, err)
+	assert.Error(t, expected.Message.AssertEquivalent(differing.Message))
+
+	// A different blockhash must still fail.
+	otherBlockhash, err := solana.NewTransaction(
+		[]solana.Instruction{
+			buildCreateWithoutRent(t, payer, wallet, mint, tokenProgramID, false),
+		},
+		solana.MustHashFromBase58("EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N"),
+		solana.TransactionPayer(payer),
+	)
+	require.NoError(t, err)
+	assert.Error(t, expected.Message.AssertEquivalent(otherBlockhash.Message))
+}


### PR DESCRIPTION
  **Summary**

  The associated token account program no longer requires the rent sysvar account in Create instructions, and newer client libraries (e.g. the updated solana-kotlin used by Android for investments) omit it. Sling backend
  validation rebuilds the expected transaction in the legacy 7-account format and Message.AssertEquivalent rejected the new 6-account format with:

  - account keys: "SysvarRent111111111111111111111111111111111" not found
  - mismatched numReadonlyUnsignedAccounts header counts
  - expected account meta at index '6', but got nothing for associatedtokenaccount.Create

  **Changes**

  - Create.AssertEquivalent now compares the six required accounts (payer, ATA, wallet, mint, system program, token program) strictly, and treats a trailing rent-sysvar meta as optional on either side independently. When
  present it must be exactly the read-only, non-signer rent sysvar — any other trailing account, a writable rent meta, or more than 7 accounts still fail.
  - Message.assertEquivalent tolerates the rent sysvar being referenced by exactly one of the two messages (as a read-only unsigned static account): it is skipped in the order-agnostic account-key comparison and excluded from
  the numReadonlyUnsignedAccounts header comparison. All other differences still fail.
  - Build() is unchanged — backend-built transactions still emit the legacy 7-account format, so transaction bytes we produce are identical to before. This change only loosens validation, in both directions: old clients that
  include the rent account and new clients that omit it are both accepted.

  **Safety**

  The rent sysvar is a fixed-address, read-only, non-signer sysvar. It cannot sign, cannot be written to, and the ATA program ignores it in modern versions — so its presence or absence in the account list cannot change what a
  transaction is able to do. The tolerance is scoped to exactly that account in exactly that placement (read-only unsigned); a rent account appearing as a signer or writable account is not tolerated.

  **Testing**

  - New instruction-level equivalence tests: with-rent vs without-rent accepted in both directions; wrong trailing account, writable rent meta, extra accounts, and missing required accounts all rejected.
  - New message-level tests: wire roundtrip of a rent-less client transaction against a with-rent expected transaction passes both directions; a differing wallet or blockhash still fails even when the rent difference is
  tolerated.
  - Full fork test suite passes (go test . ./programs/...).
  - Verified against the Sling platform via a local go.work replace: test/TestTxCreateDepositAndTokenWithdrawal e2e and the solanatransaction, txtokenwithdrawal, txp2p, and txtokendeposit domain tests all pass.
